### PR TITLE
Option to save full sized image

### DIFF
--- a/CommandLineTools/GenerateLesionSegmentation/GenerateLesionSegmentation.xml
+++ b/CommandLineTools/GenerateLesionSegmentation/GenerateLesionSegmentation.xml
@@ -34,6 +34,17 @@
       <description><![CDATA[Output level set of the segmented nodule. The nodule boundary is set at the -0.5 level]]></description>
       <default>NA</default>
     </image>
+
+    <boolean>
+      <name>fullSizeOutput</name>
+      <label>Full size output</label>
+      <default>false</default>
+      <flag>f</flag>
+      <longflag>fulloutput</longflag>
+      <description>Resample the output levelset to match the input image.</description>
+    </boolean>
+
+    
     </parameters>
   
     <parameters>


### PR DESCRIPTION
The level set output, by default, is the small VOI used for processing.  If the
"-f" or "--fulloutput" flag is set, save the level set as a full sized image of
the same size is the input.  This option is useful for processes that may not
honor origin and/or spacing in NIFTI files.

Add boolean option to GenerateLesionSegmentation.xml and logic to
GenerateLesionSegmentation.cxx.