### PR TITLE
COMP: Fix build error C2899: typename cannot be used outside a template decl

### DIFF
--- a/CommandLineTools/ComputeStrainFromDeformationField/ComputeStrainFromDeformationField.cxx
+++ b/CommandLineTools/ComputeStrainFromDeformationField/ComputeStrainFromDeformationField.cxx
@@ -50,9 +50,9 @@ int main( int argc, char * argv[] )
 
     typedef itk::Image< PixelType, Dimension >         ImageType;
     typedef itk::ImageFileReader<ImageType> ReaderType;
-    typedef typename itk::Transform<PixelType, Dimension, Dimension> TransformType;
-    typedef typename itk::CompositeTransform<PixelType, Dimension> CompositeTransformType;
-    typename TransformType::Pointer transform;
+    typedef itk::Transform<PixelType, Dimension, Dimension> TransformType;
+    typedef itk::CompositeTransform<PixelType, Dimension> CompositeTransformType;
+    typedef TransformType::Pointer transform;
 
     //Read deformation field
     typedef itk::Vector< PixelType, Dimension >          VectorPixelType;


### PR DESCRIPTION
This commit update ComputeStrainFromDeformationField CLI to fix Visual Studio 2013 build errors like the following:

```
D:\D\N\S-1-E-b\Chest_Imaging_Platform-build\CIP\CommandLineTools\ComputeStrainFromDeformationField\ComputeStrainFromDeformationField.cxx(53):
  error C2899: typename cannot be used outside a template declaration [D:\D\N\S-1-E-b\Chest_Imaging_Platform-build\CIP-build\CommandLineTools\ComputeStrainFromDeformationField\ComputeStrainFromDeformationFieldLib.vcxproj] [D:\D\N\S-1-E-b\Chest_Imaging_Platform-build\CIP.vcxproj]
```

See http://slicer.cdash.org/viewBuildError.php?buildid=1086191