### PR TITLE
Fixes to the RescaleLabelMap CLI utility

### DIFF
--- a/CommandLineTools/RescaleLabelMap/RescaleLabelMap.cxx
+++ b/CommandLineTools/RescaleLabelMap/RescaleLabelMap.cxx
@@ -8,19 +8,89 @@
 
 namespace
 {   
+
+
+  template <unsigned int TDimension> typename itk::Image<unsigned short, TDimension>::Pointer
+  UpDownSample (typename itk::Image<unsigned short, TDimension>::Pointer inputImage, 
+    unsigned int downScale, unsigned int upScale)
+  {
+    return NULL;
+  }
+
+  template<>
+  typename itk::Image<unsigned short, 2>::Pointer
+  UpDownSample<2> (typename itk::Image<unsigned short, 2>::Pointer inputImage, 
+    unsigned int downScale, unsigned int upScale)
+  {
+    typedef itk::Image<unsigned short, 2> LabelMapType;
+    typedef itk::CastImageFilter< LabelMapType, cip::LabelMapSliceType > CasterTempTo2dType;
+    typedef itk::CastImageFilter< cip::LabelMapSliceType, LabelMapType > Caster2dToTempType;
+
+    typename CasterTempTo2dType::Pointer caster = CasterTempTo2dType::New();
+	  caster->SetInput( inputImage );
+	  caster->Update();
+
+	  cip::LabelMapSliceType::Pointer tmp = cip::LabelMapSliceType::New();
+    tmp = caster->GetOutput();
+
+	  if ( downScale > 1 )
+	  {
+	    tmp = cip::DownsampleLabelMapSlice( downScale, tmp );
+	  }
+	  else if ( upScale > 1 )
+	  {
+	    tmp = cip::UpsampleLabelMapSlice( upScale, tmp );
+	  }
+
+	  typename Caster2dToTempType::Pointer tmpCaster = Caster2dToTempType::New();
+	  tmpCaster->SetInput( tmp );
+	  tmpCaster->Update();
+	
+	  return tmpCaster->GetOutput();
+  }
+
+  template<>
+  typename itk::Image<unsigned short, 3>::Pointer
+  UpDownSample<3> (typename itk::Image<unsigned short, 3>::Pointer inputImage, 
+    unsigned int downScale, unsigned int upScale)
+  {
+    typedef itk::Image<unsigned short, 3> LabelMapType;
+    typedef itk::CastImageFilter< LabelMapType, cip::LabelMapType >      CasterTempTo3dType;
+    typedef itk::CastImageFilter< cip::LabelMapType, LabelMapType >      Caster3dToTempType;
+
+    typename CasterTempTo3dType::Pointer caster = CasterTempTo3dType::New();
+	  caster->SetInput( inputImage );
+	  caster->Update();
+
+	  cip::LabelMapType::Pointer tmp = cip::LabelMapType::New();
+    tmp = caster->GetOutput();
+
+	  if ( downScale > 1 )
+	  {
+	    tmp = cip::DownsampleLabelMap( downScale, tmp );
+	  }
+  	else if ( upScale > 1 )
+	  {
+	    tmp = cip::UpsampleLabelMap( upScale, tmp );
+	  } 
+    
+	  typename Caster3dToTempType::Pointer tmpCaster = Caster3dToTempType::New();
+	  tmpCaster->SetInput( tmp );
+	  tmpCaster->Update();
+	
+	  return tmpCaster->GetOutput();
+  }
+  
+
   template <unsigned int TDimension>
   int DoIT(int argc, char * argv[])
-  {    
+  {
     PARSE_ARGS;
 
     typedef itk::Image< unsigned short, TDimension >                     LabelMapType;
     typedef itk::ImageFileReader< LabelMapType >                         LabelMapReaderType;
     typedef itk::ImageFileWriter< LabelMapType >                         LabelMapWriterType;
-    typedef itk::CastImageFilter< LabelMapType, cip::LabelMapType >      CasterTempTo3dType;
-    typedef itk::CastImageFilter< cip::LabelMapType, LabelMapType >      Caster3dToTempType;
-    typedef itk::CastImageFilter< LabelMapType, cip::LabelMapSliceType > CasterTempTo2dType;
-    typedef itk::CastImageFilter< cip::LabelMapSliceType, LabelMapType > Caster2dToTempType;
-
+    
     std::cout << "Reading label map..." << std::endl;
     typename LabelMapReaderType::Pointer reader = LabelMapReaderType::New();
       reader->SetFileName( labelMapFileName );
@@ -37,52 +107,9 @@ namespace
       }
 
     typename LabelMapType::Pointer outLabelMap = LabelMapType::New();
-
-    if ( TDimension == 3 )
-      {
-	typename CasterTempTo3dType::Pointer caster = CasterTempTo3dType::New();
-	  caster->SetInput( reader->GetOutput() );
-	  caster->Update();
-
-	cip::LabelMapType::Pointer tmp = cip::LabelMapType::New();
-	if ( downScale > 1 )
-	  {
-	    tmp = cip::DownsampleLabelMap( downScale, caster->GetOutput() );
-	  }
-	else if ( upScale > 1 )
-	  {
-	    tmp = cip::UpsampleLabelMap( upScale, caster->GetOutput() );
-	  }
-
-	typename Caster3dToTempType::Pointer tmpCaster = Caster3dToTempType::New();
-	  tmpCaster->SetInput( tmp );
-	  tmpCaster->Update();
-	
-	outLabelMap = tmpCaster->GetOutput();
-      }
-    else if ( TDimension == 2 )
-      {
-	typename CasterTempTo2dType::Pointer caster = CasterTempTo2dType::New();
-	  caster->SetInput( reader->GetOutput() );
-	  caster->Update();
-
-	cip::LabelMapSliceType::Pointer tmp = cip::LabelMapSliceType::New();
-	if ( downScale > 1 )
-	  {
-	    tmp = cip::DownsampleLabelMapSlice( downScale, caster->GetOutput() );
-	  }
-	else if ( upScale > 1 )
-	  {
-	    tmp = cip::UpsampleLabelMapSlice( upScale, caster->GetOutput() );
-	  }
-
-	typename Caster2dToTempType::Pointer tmpCaster = Caster2dToTempType::New();
-	  tmpCaster->SetInput( tmp );
-	  tmpCaster->Update();
-	
-	outLabelMap = tmpCaster->GetOutput();
-      }
-  
+    
+    outLabelMap = UpDownSample<TDimension>(reader->GetOutput(), downScale, upScale);
+              
     // Write the resampled label map to file
     std::cout << "Writing rescaled label map..." << std::endl;
     typename LabelMapWriterType::Pointer writer = LabelMapWriterType::New();
@@ -104,7 +131,7 @@ namespace
     std::cout << "DONE." << std::endl;   
     return cip::EXITSUCCESS;
   }
-  
+
 } // end of anonymous namespace
 
 int main( int argc, char *argv[] )

--- a/CommandLineTools/RescaleLabelMap/RescaleLabelMap.xml
+++ b/CommandLineTools/RescaleLabelMap/RescaleLabelMap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <executable>
   <category>Chest Imaging Platform.Toolkit.Processing</category>
-  <title>ResampleLabelMap</title>
+  <title>RescaleLabelMap</title>
   <description><![CDATA[This program rescales (either upsamples or downsamples) a label map by a specified amount]]></description>
   <version>0.0.1</version>
   <documentation-url>https://chestimagingplatform.org/processing</documentation-url>

--- a/Common/cipHelper.cxx
+++ b/Common/cipHelper.cxx
@@ -152,6 +152,7 @@ template<typename ImageType, typename InterpolatorType, unsigned int D> typename
     resizeFilter->SetInterpolator( imageInterpolator );
     resizeFilter->SetOutputOrigin( inputImage->GetOrigin() );
     resizeFilter->SetOutputSpacing( outputSpacing );
+    resizeFilter->SetOutputDirection( inputImage->GetDirection() );
     resizeFilter->SetSize( outputSize );
     resizeFilter->SetInput( inputImage );
     resizeFilter->Update();
@@ -179,7 +180,7 @@ cip::LabelMapType::Pointer cip::UpsampleLabelMap(unsigned short samplingAmount, 
 
   typedef itk::NearestNeighborInterpolateImageFunction<cip::LabelMapType, double>  InterpolatorType;
   return cip::UpsampleImage<cip::LabelMapType,InterpolatorType,3>(samplingAmount,inputLabelMap);
-  
+
 }
 
 cip::LabelMapSliceType::Pointer cip::UpsampleLabelMapSlice(unsigned short samplingAmount, cip::LabelMapSliceType::Pointer inputLabelMap)
@@ -226,10 +227,11 @@ template<typename ImageType, typename InterpolatorType, unsigned int D> typename
 
 
   typename ResampleType::Pointer resizeFilter = ResampleType::New();
-    resizeFilter->SetTransform( idTransform );
+//    resizeFilter->SetTransform( idTransform );
     resizeFilter->SetInterpolator( imageInterpolator );
     resizeFilter->SetOutputOrigin( inputImage->GetOrigin() );
     resizeFilter->SetOutputSpacing( outputSpacing );
+    resizeFilter->SetOutputDirection( inputImage->GetDirection() );
     resizeFilter->SetSize( outputSize );
     resizeFilter->SetInput( inputImage );
     resizeFilter->Update();


### PR DESCRIPTION
- Fix the tool name in the XML file

- Send explicitly 2D and 3D code into specialized template, otherwise GCC8 gives compilation errors when trying to instantiate mixed dimensionality templates.

- Provide the input label direction matrix to itk::ResampleImageFilter, otherwise it fails for   rotated or reflexed images.