### PR TITLE
COMP: fixes for ITK 5 / Slicer 5 / C++11

### DIFF
--- a/CommandLineTools/ClassifyFissureParticles/ClassifyFissureParticles.cxx
+++ b/CommandLineTools/ClassifyFissureParticles/ClassifyFissureParticles.cxx
@@ -327,7 +327,7 @@ void GetParticleDistanceAndAngle( vtkPolyData* particles, unsigned int whichPart
     newtonOptimizer->Update();
     newtonOptimizer->GetOptimalParameters( optimalParams );
 
-  *distance = vcl_sqrt( newtonOptimizer->GetOptimalValue() );
+  *distance = std::sqrt( newtonOptimizer->GetOptimalValue() );
 
   tps.GetSurfaceNormal( (*optimalParams)[0], (*optimalParams)[1], normal );
 

--- a/CommandLineTools/ComputeAirwayWallFromImages/ComputeAirwayWallFromImages.cxx
+++ b/CommandLineTools/ComputeAirwayWallFromImages/ComputeAirwayWallFromImages.cxx
@@ -239,9 +239,9 @@ int main( int argc, char *argv[] )
     float ao = ellipse->GetComponent(zz,4);
     float bo = ellipse->GetComponent(zz,3);
     
-    phenotypesFile << vcl_sqrt(ai*bi) << ",";
-    phenotypesFile << vcl_sqrt(ao*bo) << ",";
-    phenotypesFile << (ao*bo-ai*bi)/(vcl_sqrt(ai*bi)+sqrt(ao*bo)) << ",";
+    phenotypesFile << std::sqrt(ai*bi) << ",";
+    phenotypesFile << std::sqrt(ao*bo) << ",";
+    phenotypesFile << (ao*bo-ai*bi)/(std::sqrt(ai*bi)+std::sqrt(ao*bo)) << ",";
     
     for (int c=0; c<3;c++)
     {

--- a/CommandLineTools/ComputeFeatureStrength/ComputeFeatureStrength.cxx
+++ b/CommandLineTools/ComputeFeatureStrength/ComputeFeatureStrength.cxx
@@ -43,7 +43,7 @@ namespace
       {
       std::cerr << "Exception caught reading CT image:";
       std::cerr << excp << std::endl;
-      return NULL;
+      return nullptr;
       }
     
     return reader->GetOutput();
@@ -122,14 +122,14 @@ int main( int argc, char *argv[] )
     
     
   // Set threads
-  unsigned int maxThreads = itk::MultiThreader::GetGlobalDefaultNumberOfThreads();
+  unsigned int maxThreads = itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads();
   
   if (threads == 0)
     {
       threads = maxThreads;
     }
   
-  itk::MultiThreader::SetGlobalMaximumNumberOfThreads( maxThreads );
+  itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads( maxThreads );
   
     
   // Read the input image now that filter is good to go
@@ -138,7 +138,7 @@ int main( int argc, char *argv[] )
   std::cout << "Reading CT from file..." << std::endl;
   ctImage = ReadCTFromFile( ctFileName );
 
-  if (ctImage.GetPointer() == NULL)
+  if (ctImage.GetPointer() == nullptr)
     {
         return cip::NRRDREADFAILURE;
     }
@@ -425,7 +425,7 @@ int main( int argc, char *argv[] )
     
   std::cout<< "DONE." << std::endl;
   
-  multiScaleFilter = NULL;
+  multiScaleFilter = nullptr;
   return cip::EXITSUCCESS;
 }
 

--- a/CommandLineTools/CropLung/CropLung.cxx
+++ b/CommandLineTools/CropLung/CropLung.cxx
@@ -54,13 +54,13 @@ namespace
     reader->SetFileName( fileName );
     try
       {
-	reader->Update();
+      reader->Update();
       }
     catch ( itk::ExceptionObject &excp )
       {
-	std::cerr << "Exception caught reading CT image:";
-	std::cerr << excp << std::endl;
-	return NULL;
+      std::cerr << "Exception caught reading CT image:";
+      std::cerr << excp << std::endl;
+      return cip::CTType::Pointer(nullptr);
       }
     
     return reader->GetOutput();
@@ -164,10 +164,10 @@ int main( int argc, char *argv[] )
       std::cout << "Reading CT from file..." << std::endl;
       ctImage = ReadCTFromFile( ctFileName );
       
-      if (ctImage.GetPointer() == NULL)
-	{
-	  return cip::NRRDREADFAILURE;
-	}
+      if (ctImage.GetPointer() == nullptr)
+        {
+          return cip::NRRDREADFAILURE;
+        }
     }
   else
     {
@@ -186,10 +186,10 @@ int main( int argc, char *argv[] )
       std::cout << "Reading label map from file..." << std::endl;
       labelMap = ReadLabelMapFromFile( plInputFileName );
       
-      if (labelMap.GetPointer() == NULL)
-	{
-	  return cip::LABELMAPREADFAILURE;
-	}
+      if (labelMap.GetPointer() == nullptr)
+        {
+          return cip::LABELMAPREADFAILURE;
+        }
     }
   else
     {

--- a/CommandLineTools/EvaluateLungLobeSegmentationResults/EvaluateLungLobeSegmentationResults.cxx
+++ b/CommandLineTools/EvaluateLungLobeSegmentationResults/EvaluateLungLobeSegmentationResults.cxx
@@ -416,11 +416,11 @@ void PrintStats( std::vector< double > distances )
     }
   std /= static_cast< double >( distances.size() );
 
-  std = vcl_sqrt( std );
+  std = std::sqrt( std );
   std::cout << "STD:\t" << std << std::endl;
 
   std::cout << "Max:\t" << maxDist << std::endl;
-  std::cout << "RMS:\t" << vcl_sqrt(rms/static_cast< double >( distances.size() )) << std::endl;
+  std::cout << "RMS:\t" << std::sqrt(rms/static_cast< double >( distances.size() )) << std::endl;
 }
 
 
@@ -465,7 +465,7 @@ double GetDistanceFromPointToThinPlateSplineSurface( double x, double y, double 
   // is just the square root of the objective function value
   // optimized by the Newton method.
   //
-  double distance = vcl_sqrt( optimizer->GetOptimalValue() );
+  double distance = std::sqrt( optimizer->GetOptimalValue() );
 
 //  delete particleToTPSMetric;  
   delete optimizer;

--- a/CommandLineTools/GenerateLesionSegmentation/GenerateLesionSegmentation.cxx
+++ b/CommandLineTools/GenerateLesionSegmentation/GenerateLesionSegmentation.cxx
@@ -20,7 +20,8 @@ typedef itk::Image< PixelType, ImageDimension > InputImageType;
 typedef itk::Image< float, ImageDimension > RealImageType;
 
 typedef itk::LandmarkSpatialObject< 3 >    SeedSpatialObjectType;
-typedef SeedSpatialObjectType::PointListType   PointListType;
+typedef SeedSpatialObjectType::LandmarkPointType   LandmarkPointType;
+typedef SeedSpatialObjectType::LandmarkPointListType   LandmarkPointListType;
 typedef InputImageType::IndexType IndexType;
 
 typedef itk::ImageFileReader< InputImageType > InputReaderType;
@@ -33,11 +34,11 @@ typedef itk::ResampleImageFilter<RealImageType,RealImageType> ResampleImageFilte
 typedef itk::IdentityTransform<double, ImageDimension> TransformType;
 typedef itk::NearestNeighborExtrapolateImageFunction<RealImageType,double> ExtrapolatorType;
 
-PointListType GetSeeds(std::vector<std::vector<float> > seeds,InputImageType *image)
+LandmarkPointListType GetSeeds(std::vector<std::vector<float> > seeds,InputImageType *image)
 {
   
   const unsigned int nb_of_markers = seeds.size();
-  PointListType seedsList(seeds.size());
+  LandmarkPointListType seedsList(seeds.size());
   
   for (unsigned int i = 0; i < seeds.size(); i++)
   {
@@ -55,8 +56,7 @@ PointListType GetSeeds(std::vector<std::vector<float> > seeds,InputImageType *im
       << image->GetBufferedRegion() << std::endl;
       
     } else {
-      
-      seedsList[i].SetPosition(seeds[i][0],seeds[i][1],seeds[i][2]);
+      seedsList[i].SetPositionInWorldSpace(pointSeed);
       
     }
   }
@@ -114,12 +114,12 @@ int main( int argc, char * argv[] )
   if (roi[0] == 0 && roi[1] == 0 && roi[2]==0 &&
       roi[3] == 0 && roi[4] ==0 && roi[5]==0){
     //Compute ROI from seed and maximum Radius
-    PointListType seeds=GetSeeds(seedsFiducials,image);
+    LandmarkPointListType seeds=GetSeeds(seedsFiducials,image);
     seeds[0];
     for (int i=0; i < 3; i++)
     {
-      roi[2*i]= seeds[0].GetPosition()[i] - maximumRadius;
-      roi[2*i+1]= seeds[0].GetPosition()[i] + maximumRadius;
+      roi[2*i]= seeds[0].GetPositionInWorldSpace()[i] - maximumRadius;
+      roi[2*i+1]= seeds[0].GetPositionInWorldSpace()[i] + maximumRadius;
     }
   }
   

--- a/CommandLineTools/GenerateLobeSurfaceModels/GenerateLobeSurfaceModelsHelper.cxx
+++ b/CommandLineTools/GenerateLobeSurfaceModels/GenerateLobeSurfaceModelsHelper.cxx
@@ -637,7 +637,7 @@ PCA GetHighDimensionPCA( std::vector< std::vector< double > > valuesVecVec )
       u = Xt*eig.get_eigenvector( numVecs-v-1 );
 
       // Compute u's magnitude
-      double mag = vcl_sqrt( dot_product( u, u ) );
+      double mag = std::sqrt( dot_product( u, u ) );
 
       for ( unsigned int z=0; z<numZvals; z++ )
         {

--- a/CommandLineTools/GenerateParenchymaPhenotypes/GenerateParenchymaPhenotypes.cxx
+++ b/CommandLineTools/GenerateParenchymaPhenotypes/GenerateParenchymaPhenotypes.cxx
@@ -175,7 +175,7 @@ struct PARENCHYMAPHENOTYPES
             histSTD += static_cast< double >( histogram[i] )*std::pow( static_cast< double >(i) - mean, 2 );
         }
         
-        histSTD = vcl_sqrt( histSTD/static_cast< double >( counts ) );
+        histSTD = std::sqrt( histSTD/static_cast< double >( counts ) );
         
         return histSTD;
     }

--- a/CommandLineTools/GenerateRegionHistogramsAndParenchymaPhenotypes/GenerateRegionHistogramsAndParenchymaPhenotypes.cxx
+++ b/CommandLineTools/GenerateRegionHistogramsAndParenchymaPhenotypes/GenerateRegionHistogramsAndParenchymaPhenotypes.cxx
@@ -175,7 +175,7 @@ struct PARENCHYMAPHENOTYPES
             histSTD += static_cast< double >( histogram[i] )*std::pow( static_cast< double >(i) - mean, 2 );
         }
         
-        histSTD = vcl_sqrt( histSTD/static_cast< double >( counts ) );
+        histSTD = std::sqrt( histSTD/static_cast< double >( counts ) );
         
         return histSTD;
     }

--- a/CommandLineTools/GetTransformationSimilarityMetric/GetTransformationSimilarityMetric.cxx
+++ b/CommandLineTools/GetTransformationSimilarityMetric/GetTransformationSimilarityMetric.cxx
@@ -146,13 +146,13 @@ struct REGIONTYPEPAIR
     reader->SetFileName( fileName );
     try
       {
-	reader->Update();
+      reader->Update();
       }
     catch ( itk::ExceptionObject &excp )
       {
-	std::cerr << "Exception caught reading CT image:";
-	std::cerr << excp << std::endl;
-	return NULL;
+      std::cerr << "Exception caught reading CT image:";
+      std::cerr << excp << std::endl;
+      return nullptr;
       }
 
     return reader->GetOutput();
@@ -163,35 +163,35 @@ struct REGIONTYPEPAIR
    void WriteMeasuresXML(const char *file, SIMILARITY_XML_DATA &theXMLData)
   {
     std::cout<<"Writing similarity XML file"<<std::endl;
-    xmlDocPtr doc = NULL;       /* document pointer */
-    xmlNodePtr root_node = NULL; /* Node pointers */
-    xmlDtdPtr dtd = NULL;       /* DTD pointer */
+    xmlDocPtr doc = nullptr;       /* document pointer */
+    xmlNodePtr root_node = nullptr; /* Node pointers */
+    xmlDtdPtr dtd = nullptr;       /* DTD pointer */
     xmlAttrPtr newattr;
 
     xmlNodePtr transfo_node[5];
 
     for(int i = 0; i< 5; i++)
-      transfo_node[i]= NULL;
+      transfo_node[i]= nullptr;
 
 
     doc = xmlNewDoc(BAD_CAST "1.0");
-    root_node = xmlNewNode(NULL, BAD_CAST "Inter_Subject_Measure");
+    root_node = xmlNewNode(nullptr, BAD_CAST "Inter_Subject_Measure");
     xmlDocSetRootElement(doc, root_node);
 
-    dtd = xmlCreateIntSubset(doc, BAD_CAST "root", NULL, BAD_CAST "InterSubjectMeasures_v3.dtd");
+    dtd = xmlCreateIntSubset(doc, BAD_CAST "root", nullptr, BAD_CAST "InterSubjectMeasures_v3.dtd");
 
     // xmlNewChild() creates a new node, which is "attached"
     // as child node of root_node node.
     std::ostringstream similaritString;
     similaritString <<theXMLData.similarityValue;
 
-    xmlNewChild(root_node, NULL, BAD_CAST "movingID", BAD_CAST (theXMLData. movingID.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "fixedID", BAD_CAST (theXMLData.fixedID.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "movingMask", BAD_CAST (theXMLData. movingMask.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "fixedMask", BAD_CAST (theXMLData.fixedMask.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "SimilarityMeasure", BAD_CAST (theXMLData.similarityMeasure.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "SimilarityValue", BAD_CAST (similaritString.str().c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "ImageExtension", BAD_CAST (theXMLData.extention.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "movingID", BAD_CAST (theXMLData. movingID.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "fixedID", BAD_CAST (theXMLData.fixedID.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "movingMask", BAD_CAST (theXMLData. movingMask.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "fixedMask", BAD_CAST (theXMLData.fixedMask.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "SimilarityMeasure", BAD_CAST (theXMLData.similarityMeasure.c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "SimilarityValue", BAD_CAST (similaritString.str().c_str()));
+    xmlNewChild(root_node, nullptr, BAD_CAST "ImageExtension", BAD_CAST (theXMLData.extention.c_str()));
 
 
 
@@ -199,8 +199,8 @@ struct REGIONTYPEPAIR
       {
         if (!theXMLData.transformationLink[i].empty())
 	  {
-            transfo_node[i] = xmlNewChild(root_node, NULL, BAD_CAST "transformation", BAD_CAST (""));
-            xmlNewChild(transfo_node[i], NULL, BAD_CAST "file", BAD_CAST (theXMLData.transformationLink[i].c_str()));
+            transfo_node[i] = xmlNewChild(root_node, nullptr, BAD_CAST "transformation", BAD_CAST (""));
+            xmlNewChild(transfo_node[i], nullptr, BAD_CAST "file", BAD_CAST (theXMLData.transformationLink[i].c_str()));
             newattr = xmlNewProp(transfo_node[i], BAD_CAST "isInverse", BAD_CAST (theXMLData.transformation_isInverse[i].c_str()));
             std::ostringstream order_string;
             order_string << theXMLData.transformation_order[i];
@@ -266,14 +266,14 @@ typedef itk::GradientDifferenceImageToImageMetric<ShortImageType, ShortImageType
     //Read the CT images
   typename ShortImageType::Pointer ctFixedImage = ShortImageType::New();
   ctFixedImage = ReadCTFromFile<TDimension>( fixedCTFileName );
-  if (ctFixedImage.GetPointer() == NULL)
+  if (ctFixedImage.GetPointer() == nullptr)
       {
         return cip::NRRDREADFAILURE;
       }
 
   typename ShortImageType::Pointer ctMovingImage = ShortImageType::New();
   ctMovingImage = ReadCTFromFile<TDimension>( movingCTFileName);
-  if (ctMovingImage.GetPointer() == NULL)
+  if (ctMovingImage.GetPointer() == nullptr)
       {
         return cip::NRRDREADFAILURE;
       }

--- a/CommandLineTools/ReadDicomWriteTags/ReadDicomWriteTags.cxx
+++ b/CommandLineTools/ReadDicomWriteTags/ReadDicomWriteTags.cxx
@@ -238,24 +238,24 @@ namespace
     tagValue = entryValue->GetMetaDataObjectValue();
         
     // Replace commas and new-lines with spaces
-    unsigned int commaLocation = tagValue.find( ',' );
+    size_t commaLocation = tagValue.find( ',' );
     
     //First check if comma exists
     if (commaLocation <tagValue.length())
       {
         if ( commaLocation != std::string::npos )
-	  {
+          {
             tagValue.replace( commaLocation, 1, " " );
-	  }
+	        }
         
-        unsigned int newlineLocation = tagValue.find( '\n' );
+        size_t newlineLocation = tagValue.find( '\n' );
         if ( newlineLocation != std::string::npos )
-	  {
+	        {
             if (newlineLocation<tagValue.length())
-	      {
+	            {
                 tagValue.replace( newlineLocation, 1, " " );
-	      }
-	  }
+	            }
+	        }
       }
     
     return tagValue;

--- a/CommandLineTools/RegisterCT/RegisterCT.cxx
+++ b/CommandLineTools/RegisterCT/RegisterCT.cxx
@@ -109,13 +109,13 @@ namespace
     reader->SetFileName( fileName );
     try
       {
-	reader->Update();
+      reader->Update();
       }
     catch ( itk::ExceptionObject &excp )
       {
-	std::cerr << "Exception caught reading CT image:";
-	std::cerr << excp << std::endl;
-	return NULL;
+      std::cerr << "Exception caught reading CT image:";
+      std::cerr << excp << std::endl;
+      return nullptr;
       }
     
     return reader->GetOutput();
@@ -125,15 +125,15 @@ namespace
 			    &theXMLData)
   {
     std::cout<<"Writing registration XML file"<<std::endl;
-    xmlDocPtr doc = NULL;       /* document pointer */
-    xmlNodePtr root_node = NULL; /* Node pointers */
-    xmlDtdPtr dtd = NULL;       /* DTD pointer */
+    xmlDocPtr doc = nullptr;       /* document pointer */
+    xmlNodePtr root_node = nullptr; /* Node pointers */
+    xmlDtdPtr dtd = nullptr;       /* DTD pointer */
     
     doc = xmlNewDoc(BAD_CAST "1.0");
-    root_node = xmlNewNode(NULL, BAD_CAST "Registration");
+    root_node = xmlNewNode(nullptr, BAD_CAST "Registration");
     xmlDocSetRootElement(doc, root_node);
     
-    dtd = xmlCreateIntSubset(doc, BAD_CAST "root", NULL, BAD_CAST
+    dtd = xmlCreateIntSubset(doc, BAD_CAST "root", nullptr, BAD_CAST
 			     "RegistrationOutput_v2.dtd");
     
     time_t timer;
@@ -158,19 +158,19 @@ namespace
     std::ostringstream transformationIndexString;
     transformationIndexString <<theXMLData.transformationIndex;
     
-    xmlNewChild(root_node, NULL, BAD_CAST "image_type", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "image_type", BAD_CAST
 		(theXMLData.image_type.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "transformation", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "transformation", BAD_CAST
 		(theXMLData.transformationLink.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "transformation_index", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "transformation_index", BAD_CAST
 		(transformationIndexString.str().c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "movingID", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "movingID", BAD_CAST
 		(theXMLData.sourceID.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "fixedID", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "fixedID", BAD_CAST
 		(theXMLData.destID.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "SimilarityMeasure", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "SimilarityMeasure", BAD_CAST
 		(theXMLData.similarityMeasure.c_str()));
-    xmlNewChild(root_node, NULL, BAD_CAST "SimilarityValue", BAD_CAST
+    xmlNewChild(root_node, nullptr, BAD_CAST "SimilarityValue", BAD_CAST
 		(similaritString.str().c_str()));
     xmlSaveFormatFileEnc(file, doc, "UTF-8", 1);
     xmlFreeDoc(doc);
@@ -259,9 +259,9 @@ int DoIT2(int argc, char * argv[])
       std::cout << "Reading CT from file..." << std::endl;
       
       fixedCT = ReadCTFromFile< TDimension > ( fixedImageFileName );
-      if (fixedCT.GetPointer() == NULL)
+      if (fixedCT.GetPointer() == nullptr)
         {
-	  return cip::LABELMAPREADFAILURE;
+        return cip::LABELMAPREADFAILURE;
         }
       
     }
@@ -280,7 +280,7 @@ int DoIT2(int argc, char * argv[])
       
       movingCT = ReadCTFromFile< TDimension > ( movingImageFileName );
       
-      if (movingCT.GetPointer() == NULL)
+      if (movingCT.GetPointer() == nullptr)
         {
 	  return cip::LABELMAPREADFAILURE;
         }
@@ -636,9 +636,9 @@ int DoIT3(int argc, char * argv[])
       std::cout << "Reading CT from file..." << std::endl;
       
       fixedCT = ReadCTFromFile< TDimension > ( fixedImageFileName );
-      if (fixedCT.GetPointer() == NULL)
+      if (fixedCT.GetPointer() == nullptr)
         {
-	  return cip::LABELMAPREADFAILURE;
+        return cip::LABELMAPREADFAILURE;
         }
       
     }
@@ -657,9 +657,9 @@ int DoIT3(int argc, char * argv[])
       
       movingCT = ReadCTFromFile< TDimension > ( movingImageFileName );
       
-      if (movingCT.GetPointer() == NULL)
+      if (movingCT.GetPointer() == nullptr)
         {
-	  return cip::LABELMAPREADFAILURE;
+        return cip::LABELMAPREADFAILURE;
         }      
     }
   catch (cip::ExceptionObject &exep)

--- a/CommandLineTools/SegmentLungLobes/SegmentLungLobes.cxx
+++ b/CommandLineTools/SegmentLungLobes/SegmentLungLobes.cxx
@@ -405,7 +405,7 @@ void AppendFissurePoints( std::vector< cip::PointType >* fissurePoints, vtkSmart
   unsigned int maxNum = 1000;
   unsigned int added = 0;
 
-  unsigned int inc = (unsigned int)( vcl_ceil(float(particles->GetNumberOfPoints())/float(maxNum) ) );
+  unsigned int inc = (unsigned int)( std::ceil(float(particles->GetNumberOfPoints())/float(maxNum) ) );
 
   bool addPoint;
 

--- a/Common/cipAirwayParticleConnectedComponentFilter.cxx
+++ b/Common/cipAirwayParticleConnectedComponentFilter.cxx
@@ -68,7 +68,7 @@ bool cipAirwayParticleConnectedComponentFilter::EvaluateParticleConnectedness( u
   
   double maxScale;  (scale1>scale2) ? (maxScale = scale1) : (maxScale = scale2);
 
-  if ( vcl_abs(scale1 - scale2)/maxScale > this->ScaleRatioThreshold )
+  if ( std::abs(scale1 - scale2)/maxScale > this->ScaleRatioThreshold )
     {
       return false;
     }

--- a/Common/cipChestDataViewer.cxx
+++ b/Common/cipChestDataViewer.cxx
@@ -579,7 +579,7 @@ void cipChestDataViewer::SetParticles( vtkPolyData* polyData, double scaleFactor
     vals1->GetTuple( i, val1 );
     vals2->GetTuple( i, val2 );
 
-    float mag = vcl_sqrt( std::pow( *val0, 2 ) + std::pow( *val1, 2 ) + std::pow( *val2, 2 ) );
+    float mag = std::sqrt( std::pow( *val0, 2 ) + std::pow( *val1, 2 ) + std::pow( *val2, 2 ) );
 
     double vec0[3];
     double vec1[3];
@@ -607,16 +607,16 @@ void cipChestDataViewer::SetParticles( vtkPolyData* polyData, double scaleFactor
     if ( fissureParticles )
       {
       *scale = 1.0;
-      M1 *= (1 - vcl_abs( *val0/mag ));
-      M2 *= (1 - vcl_abs( *val1/mag ));
-      M3 *= (1 - vcl_abs( *val2/mag ));
+      M1 *= (1 - std::abs( *val0/mag ));
+      M2 *= (1 - std::abs( *val1/mag ));
+      M3 *= (1 - std::abs( *val2/mag ));
       }
     else
       {
       scaleArray->GetTuple( i, scale );
-      M1 *= vcl_abs( *val0/mag );
-      M2 *= vcl_abs( *val1/mag );
-      M3 *= vcl_abs( *val2/mag );
+      M1 *= std::abs( *val0/mag );
+      M2 *= std::abs( *val1/mag );
+      M3 *= std::abs( *val2/mag );
       }
 
     vnl_matrix_fixed< double, 3, 3 > tensorMat;
@@ -954,7 +954,7 @@ void cipChestDataViewer::ModifyLeftObliqueFissureByPCAMode( unsigned int whichMo
 {
 //   for ( unsigned int i=0; i<(this->LeftObliqueFissurePCAModes[whichMode]).size(); i++ )
 //     {
-//     (this->LeftObliqueFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*vcl_sqrt( this->LeftObliqueFissurePCAVariances[whichMode] )*
+//     (this->LeftObliqueFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*std::sqrt( this->LeftObliqueFissurePCAVariances[whichMode] )*
 //                                                                               (this->LeftObliqueFissurePCAModes[whichMode])[i] );
 //     }
 //   this->Renderer->RemoveActor( this->ActorMap["LEFTLUNGOBLIQUEFISSURE"] );
@@ -966,7 +966,7 @@ void cipChestDataViewer::ModifyRightObliqueFissureByPCAMode( unsigned int whichM
 {
 //   for ( unsigned int i=0; i<(this->RightObliqueFissurePCAModes[whichMode]).size(); i++ )
 //     {
-//     (this->RightObliqueFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*vcl_sqrt( this->RightObliqueFissurePCAVariances[whichMode] )*
+//     (this->RightObliqueFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*std::sqrt( this->RightObliqueFissurePCAVariances[whichMode] )*
 //                                                                               (this->RightObliqueFissurePCAModes[whichMode])[i] );
 //     }
 //   this->Renderer->RemoveActor( this->ActorMap["RIGHTLUNGOBLIQUEFISSURE"] );
@@ -978,7 +978,7 @@ void cipChestDataViewer::ModifyRightHorizontalFissureByPCAMode( unsigned int whi
 {
 //   for ( unsigned int i=0; i<(this->RightHorizontalFissurePCAModes[whichMode]).size(); i++ )
 //     {
-//     (this->RightHorizontalFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*vcl_sqrt( this->RightHorizontalFissurePCAVariances[whichMode] )*
+//     (this->RightHorizontalFissureIndices[i])[2] += static_cast< unsigned int >( stdMultiplier*std::sqrt( this->RightHorizontalFissurePCAVariances[whichMode] )*
 //                                                                                   (this->RightHorizontalFissurePCAModes[whichMode])[i] );
 //     }
 //   this->Renderer->RemoveActor( this->ActorMap["RIGHTLUNGHORIZONTALFISSURE"] );

--- a/Common/cipCylinderStencil.cxx
+++ b/Common/cipCylinderStencil.cxx
@@ -162,13 +162,13 @@ void cipCylinderStencil::ComputeStencilBoundingBox()
   radius2D[1] =  this->Orientation[0];
   if ( radius2D[0] == 0 && radius2D[1] == 0 )
     {
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius;
+    radius2D[0] = std::sqrt(2.0)*this->Radius;
     }
   else
     {
     mag = this->GetVectorMagnitude2D( radius2D );
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius*radius2D[0]/mag;
-    radius2D[1] = vcl_sqrt(2.0)*this->Radius*radius2D[1]/mag;
+    radius2D[0] = std::sqrt(2.0)*this->Radius*radius2D[0]/mag;
+    radius2D[1] = std::sqrt(2.0)*this->Radius*radius2D[1]/mag;
     }
 
   //
@@ -202,13 +202,13 @@ void cipCylinderStencil::ComputeStencilBoundingBox()
   radius2D[1] =  this->Orientation[0];
   if ( radius2D[0] == 0 && radius2D[1] == 0 )
     {
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius;
+    radius2D[0] = std::sqrt(2.0)*this->Radius;
     }
   else
     {
     mag = this->GetVectorMagnitude2D( radius2D );
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius*radius2D[0]/mag;
-    radius2D[1] = vcl_sqrt(2.0)*this->Radius*radius2D[1]/mag;
+    radius2D[0] = std::sqrt(2.0)*this->Radius*radius2D[0]/mag;
+    radius2D[1] = std::sqrt(2.0)*this->Radius*radius2D[1]/mag;
     }
 
   //
@@ -242,13 +242,13 @@ void cipCylinderStencil::ComputeStencilBoundingBox()
   radius2D[1] =  this->Orientation[1];
   if ( radius2D[0] == 0 && radius2D[1] == 0 )
     {
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius;
+    radius2D[0] = std::sqrt(2.0)*this->Radius;
     }
   else
     {
     mag = this->GetVectorMagnitude2D( radius2D );
-    radius2D[0] = vcl_sqrt(2.0)*this->Radius*radius2D[0]/mag;
-    radius2D[1] = vcl_sqrt(2.0)*this->Radius*radius2D[1]/mag;
+    radius2D[0] = std::sqrt(2.0)*this->Radius*radius2D[0]/mag;
+    radius2D[1] = std::sqrt(2.0)*this->Radius*radius2D[1]/mag;
     }
 
   //

--- a/Common/cipGeometryTopologyData.cxx
+++ b/Common/cipGeometryTopologyData.cxx
@@ -140,7 +140,7 @@ cip::GeometryTopologyData::BOUNDINGBOX* cip::GeometryTopologyData::InsertBoundin
 
   this->m_BoundingBoxes.push_back( bb );
 
-  return &bb;
+  return &bb; // TODO: this returns a pointer into the stack!
 }
 
 cip::GeometryTopologyData::BOUNDINGBOX* cip::GeometryTopologyData::InsertBoundingBox( int id,
@@ -194,7 +194,7 @@ cip::GeometryTopologyData::BOUNDINGBOX* cip::GeometryTopologyData::InsertBoundin
 
   this->m_BoundingBoxes.push_back( bb );
 
-  return &bb;
+  return &bb; // TODO: this generates a warning that we are returning a pointer to an object on the stack!
 }
 
 
@@ -251,7 +251,7 @@ cip::GeometryTopologyData::POINT* cip::GeometryTopologyData::InsertPoint( unsign
   this->FillMetaFieldsPoint(&p);
 
   this->m_Points.push_back( p );
-  return &p;
+  return &p; // TODO: this returns a pointer to an object on the stack!
 }
 
 cip::GeometryTopologyData::POINT* cip::GeometryTopologyData::InsertPoint( int id,
@@ -287,7 +287,7 @@ cip::GeometryTopologyData::POINT* cip::GeometryTopologyData::InsertPoint( int id
   p.userName = userName;
   p.machineName = machineName;
   this->m_Points.push_back( p );
-  return &p;
+  return &p; // TODO: this returns a pointer to an object on the stack!
 }
 
 void cip::GeometryTopologyData::FillMetaFieldsPoint(POINT* p){

--- a/Common/cipHelper.cxx
+++ b/Common/cipHelper.cxx
@@ -70,7 +70,7 @@ cip::CTType::Pointer cip::ReadCTFromDirectory( std::string ctDir )
   {
     std::cerr << "Exception caught while reading dicom:";
     std::cerr << excp << std::endl;
-    return NULL;
+    return cip::CTType::Pointer(nullptr);
   }
   
   return dicomReader->GetOutput();
@@ -88,7 +88,7 @@ cip::CTType::Pointer cip::ReadCTFromFile( std::string fileName )
   {
     std::cerr << "Exception caught reading CT image:";
     std::cerr << excp << std::endl;
-    return NULL;
+    return cip::CTType::Pointer(nullptr);
   }
   
   return reader->GetOutput();
@@ -106,7 +106,7 @@ cip::LabelMapType::Pointer cip::ReadLabelMapFromFile( std::string fileName )
   {
     std::cerr << "Exception caught reading Label Map image:";
     std::cerr << excp << std::endl;
-    return NULL;
+    return cip::LabelMapType::Pointer(nullptr);
   }
   
   return reader->GetOutput();
@@ -269,7 +269,7 @@ cip::LabelMapSliceType::Pointer cip::DownsampleLabelMapSlice(unsigned short samp
 
 double cip::GetVectorMagnitude(const cip::VectorType& vector)
 {
-  double magnitude = vcl_sqrt(std::pow(vector[0], 2) + std::pow(vector[1], 2) + std::pow(vector[2], 2));
+  double magnitude = std::sqrt(std::pow(vector[0], 2) + std::pow(vector[1], 2) + std::pow(vector[2], 2));
 
   return magnitude;
 }
@@ -282,12 +282,12 @@ double cip::GetAngleBetweenVectors(const cip::VectorType& vec1,
 
   double arg = (vec1[0]*vec2[0] + vec1[1]*vec2[1] + vec1[2]*vec2[2])/(vec1Mag*vec2Mag);
 
-  if ( vcl_abs( arg ) > 1.0 )
+  if ( std::abs( arg ) > 1.0 )
     {
       arg = 1.0;
     }
 
-  double angle = vcl_acos( arg );
+  double angle = std::acos( arg );
 
   if ( !returnDegrees )
     {
@@ -966,7 +966,7 @@ double cip::GetDistanceToThinPlateSplineSurface( const cipThinPlateSplineSurface
     optimizer.SetInitialParameters( domainParams );
     optimizer.Update();
 
-  double distance = vcl_sqrt( optimizer.GetOptimalValue() );
+  double distance = std::sqrt( optimizer.GetOptimalValue() );
   
   return distance;  
 }

--- a/Common/cipLabelMapToLungLobeLabelMapImageFilter.h
+++ b/Common/cipLabelMapToLungLobeLabelMapImageFilter.h
@@ -151,7 +151,7 @@ public:
    *  will gradually be preferred. */
   void SetRightHorizontalThinPlateSplineSurface( cipThinPlateSplineSurface* );
 
-  void PrintSelf( std::ostream& os, itk::Indent indent ) const;
+  void PrintSelf( std::ostream& os, itk::Indent indent ) const override;
 
 protected:
   cipLabelMapToLungLobeLabelMapImageFilter();
@@ -160,7 +160,7 @@ protected:
   typedef itk::ConnectedComponentImageFilter< OutputImageType, OutputImageType >  ConnectedComponentType;
   typedef itk::Image< float, 2 >                                                  BlendMapType;
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   cipLabelMapToLungLobeLabelMapImageFilter(const Self&); //purposely not implemented

--- a/Common/cipLeftLobesThinPlateSplineSurfaceModelToParticlesMetric.cxx
+++ b/Common/cipLeftLobesThinPlateSplineSurfaceModelToParticlesMetric.cxx
@@ -66,7 +66,7 @@ double cipLeftLobesThinPlateSplineSurfaceModelToParticlesMetric::GetValue( const
 	  // locations of the points (the x and y coordinates) remain
 	  // fixed 
 	  this->LeftObliqueSurfacePoints[p][2] += 
-	    (*params)[m]*vcl_sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
+	    (*params)[m]*std::sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
 	}
     }
 
@@ -135,7 +135,7 @@ double cipLeftLobesThinPlateSplineSurfaceModelToParticlesMetric::GetFissureTermV
     // Get the distances between the particle and the TPS surfaces. This
     // is just the square root of the objective function value
     // optimized by the Newton method.
-    double loDistance = vcl_sqrt( this->LeftObliqueNewtonOptimizer.GetOptimalValue() );
+    double loDistance = std::sqrt( this->LeftObliqueNewtonOptimizer.GetOptimalValue() );
 
     // Get the TPS surface normals at the domain locations.
     this->LeftObliqueNewtonOptimizer.GetMetric().GetThinPlateSplineSurface().
@@ -191,7 +191,7 @@ double cipLeftLobesThinPlateSplineSurfaceModelToParticlesMetric::GetVesselTermVa
     // Get the distances between the particle and the TPS surfaces. This
     // is just the square root of the objective function value
     // optimized by the Newton method.
-    double loDistance = vcl_sqrt( this->LeftObliqueNewtonOptimizer.GetOptimalValue() );
+    double loDistance = std::sqrt( this->LeftObliqueNewtonOptimizer.GetOptimalValue() );
 
     // Get the TPS surface normals at the domain locations.
     this->LeftObliqueNewtonOptimizer.GetMetric().GetThinPlateSplineSurface().

--- a/Common/cipLobeSurfaceModel.cxx
+++ b/Common/cipLobeSurfaceModel.cxx
@@ -211,7 +211,7 @@ void cipLobeSurfaceModel::ComputeRightHorizontalWeightedSurfacePoints()
 
     for ( unsigned int m=0; m<this->NumberOfModes; m++ )
       {                  
-      point[2] += this->ModeWeights[m]*vcl_sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][index];
+      point[2] += this->ModeWeights[m]*std::sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][index];
       }
 
     this->RightHorizontalWeightedSurfacePoints.push_back( point );
@@ -252,7 +252,7 @@ void cipLobeSurfaceModel::ComputeRightObliqueWeightedSurfacePoints()
 
     for ( unsigned int m=0; m<this->NumberOfModes; m++ )
       {                  
-      point[2] += this->ModeWeights[m]*vcl_sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][i];
+      point[2] += this->ModeWeights[m]*std::sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][i];
       }
 
     this->RightObliqueWeightedSurfacePoints.push_back( point );
@@ -272,7 +272,7 @@ void cipLobeSurfaceModel::ComputeWeightedSurfacePoints()
 
     for ( unsigned int m=0; m<this->NumberOfModes; m++ )
       {                  
-      point[2] += this->ModeWeights[m]*vcl_sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][i];
+      point[2] += this->ModeWeights[m]*std::sqrt( this->Eigenvalues[m] )*this->Eigenvectors[m][i];
       }
 
     this->WeightedSurfacePoints.push_back( point );

--- a/Common/cipNewtonOptimizer.txx
+++ b/Common/cipNewtonOptimizer.txx
@@ -79,7 +79,7 @@ void cipNewtonOptimizer< Dimension >::Update( bool verbose )
   //
   this->OptimalValue = this->Metric.GetValueGradientAndHessian( params, g, &h );
 
-  double gradMag = vcl_sqrt( dot_product(*g,*g) );
+  double gradMag = std::sqrt( dot_product(*g,*g) );
   double gradMagDiff = DBL_MAX;
   double gradMagLast = gradMag;
   while ( gradMagDiff > this->GradientDifferenceTolerance )
@@ -93,8 +93,8 @@ void cipNewtonOptimizer< Dimension >::Update( bool verbose )
 
     if ( d[0] < 0 || d[1] < 0 )
       {
-      h = vcl_abs(d[0])*outer_product(v.get_column(0),v.get_column(0)) + 
-        vcl_abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
+      h = std::abs(d[0])*outer_product(v.get_column(0),v.get_column(0)) + 
+        std::abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
       }
 
     (*hInv) =  vnl_matrix_inverse<double>(h);    
@@ -116,7 +116,7 @@ void cipNewtonOptimizer< Dimension >::Update( bool verbose )
     this->OptimalValue = this->Metric.GetValueGradientAndHessian( params, g, &h );
     (*this->OptimalParams) = (*params);
     
-    gradMag = vcl_sqrt( dot_product(*g,*g) );
+    gradMag = std::sqrt( dot_product(*g,*g) );
     gradMagDiff = gradMagLast - gradMag;
     gradMagLast = gradMag;
     
@@ -169,7 +169,7 @@ void cipNewtonOptimizer< Dimension >::Update()
   //
   this->OptimalValue = this->Metric.GetValueGradientAndHessian( params, g, &h );
 
-  double gradMag = vcl_sqrt( dot_product(*g,*g) );
+  double gradMag = std::sqrt( dot_product(*g,*g) );
   double gradMagDiff = DBL_MAX;
   double gradMagLast = gradMag;
   while ( gradMagDiff > this->GradientDifferenceTolerance )
@@ -183,8 +183,8 @@ void cipNewtonOptimizer< Dimension >::Update()
 
     if ( d[0] < 0 || d[1] < 0 )
       {
-      h = vcl_abs(d[0])*outer_product(v.get_column(0),v.get_column(0)) + 
-        vcl_abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
+      h = std::abs(d[0])*outer_product(v.get_column(0),v.get_column(0)) + 
+        std::abs(d[1])*outer_product(v.get_column(1),v.get_column(1));
       }
 
     (*hInv) =  vnl_matrix_inverse<double>(h);    
@@ -207,7 +207,7 @@ void cipNewtonOptimizer< Dimension >::Update()
 
     (*this->OptimalParams) = (*params);
     
-    gradMag = vcl_sqrt( dot_product(*g,*g) );
+    gradMag = std::sqrt( dot_product(*g,*g) );
     gradMagDiff = gradMagLast - gradMag;
     gradMagLast = gradMag;
     }

--- a/Common/cipParticleConnectedComponentFilter.cxx
+++ b/Common/cipParticleConnectedComponentFilter.cxx
@@ -126,7 +126,7 @@ void cipParticleConnectedComponentFilter::SetComponentSizeThreshold( unsigned in
 
 double cipParticleConnectedComponentFilter::GetVectorMagnitude( double vector[3] )
 {
-  double magnitude = vcl_sqrt( std::pow( vector[0], 2 ) + std::pow( vector[1], 2 ) + std::pow( vector[2], 2 ) );
+  double magnitude = std::sqrt( std::pow( vector[0], 2 ) + std::pow( vector[1], 2 ) + std::pow( vector[2], 2 ) );
 
   return magnitude;
 }
@@ -152,12 +152,12 @@ double cipParticleConnectedComponentFilter::GetAngleBetweenVectors( double vec1[
 
   double arg = (vec1[0]*vec2[0] + vec1[1]*vec2[1] + vec1[2]*vec2[2])/(vec1Mag*vec2Mag);
 
-  if ( vcl_abs( arg ) > 1.0 )
+  if ( std::abs( arg ) > 1.0 )
     {
     arg = 1.0;
     }
 
-  double angle = vcl_acos( arg );
+  double angle = std::acos( arg );
 
   if ( !returnDegrees )
     {

--- a/Common/cipParticleToThinPlateSplineSurfaceMetric.cxx
+++ b/Common/cipParticleToThinPlateSplineSurfaceMetric.cxx
@@ -127,12 +127,12 @@ double cipParticleToThinPlateSplineSurfaceMetric::GetValueGradientAndHessian( Po
     double xDiffi = s[0] - surfPoints[i][0];
     double yDiffi = s[1] - surfPoints[i][1];
 
-    r    = vcl_sqrt( std::pow(xDiffi,2) + std::pow(yDiffi,2) );
+    r    = std::sqrt( std::pow(xDiffi,2) + std::pow(yDiffi,2) );
     drdx = xDiffi/r;
     drdy = yDiffi/r;
 
     double rln10   = r*vnl_math::ln10;
-    double rGroup  = 2.0*vcl_log10(r) + 1.0/vnl_math::ln10;
+    double rGroup  = 2.0*std::log10(r) + 1.0/vnl_math::ln10;
     double rrGroup = r*rGroup;
 
     double d11dx  = (r-drdx*xDiffi)/std::pow(r,2);
@@ -170,12 +170,12 @@ double cipParticleToThinPlateSplineSurfaceMetric::GetAngleBetweenVectors( const 
 
   double arg = (vec1[0]*vec2[0] + vec1[1]*vec2[1] + vec1[2]*vec2[2])/(vec1Mag*vec2Mag);
 
-  if ( vcl_abs( arg ) > 1.0 )
+  if ( std::abs( arg ) > 1.0 )
     {
     arg = 1.0;
     }
 
-  double angle = vcl_acos( arg );
+  double angle = std::acos( arg );
 
   return angle;   
 }
@@ -183,7 +183,7 @@ double cipParticleToThinPlateSplineSurfaceMetric::GetAngleBetweenVectors( const 
 
 double cipParticleToThinPlateSplineSurfaceMetric::GetVectorMagnitude( const double vector[3] ) const
 {
-  double magnitude = vcl_sqrt( std::pow( vector[0], 2 ) + std::pow( vector[1], 2 ) + std::pow( vector[2], 2 ) );
+  double magnitude = std::sqrt( std::pow( vector[0], 2 ) + std::pow( vector[1], 2 ) + std::pow( vector[2], 2 ) );
 
   return magnitude;
 }

--- a/Common/cipParticlesToStenciledLabelMapImageFilter.h
+++ b/Common/cipParticlesToStenciledLabelMapImageFilter.h
@@ -59,12 +59,12 @@ public:
   typedef typename InputImageType::SizeType                     InputSizeType;
   typedef itk::ImageRegionIteratorWithIndex< OutputImageType >  IteratorType;
 
-  void PrintSelf( std::ostream& os, itk::Indent indent ) const;
+  void PrintSelf( std::ostream& os, itk::Indent indent ) const override;
 
   cipParticlesToStenciledLabelMapImageFilter();
   virtual ~cipParticlesToStenciledLabelMapImageFilter() {}
 
-  void GenerateData();
+  void GenerateData() override;
   
   /** */
   void SetStencil( cipStencil* );

--- a/Common/cipParticlesToStenciledLabelMapImageFilter.txx
+++ b/Common/cipParticlesToStenciledLabelMapImageFilter.txx
@@ -121,7 +121,7 @@ cipParticlesToStenciledLabelMapImageFilter< TInputImage >
       if ( this->ScaleStencilPatternByParticleScale )
         {
           double scale = this->ParticlesData->GetPointData()->GetArray("scale")->GetTuple(i)[0];
-          double tempRadius = vcl_sqrt(2.0)*vcl_sqrt( pow( scale, 2 ) + pow( this->CTPointSpreadFunctionSigma, 2 ) );
+          double tempRadius = std::sqrt(2.0)*std::sqrt( pow( scale, 2 ) + pow( this->CTPointSpreadFunctionSigma, 2 ) );
 
           this->Stencil->SetRadius( tempRadius );
         }
@@ -129,7 +129,7 @@ cipParticlesToStenciledLabelMapImageFilter< TInputImage >
       if ( this->DNNRadiusName != "" )
         {
           double radius = this->ParticlesData->GetPointData()->GetArray(this->DNNRadiusName.c_str())->GetTuple(i)[0];
-//          double tempRadius = vcl_sqrt(2.0) * vcl_sqrt(pow(radius, 2) + pow(this->CTPointSpreadFunctionSigma, 2));
+//          double tempRadius = std::sqrt(2.0) * std::sqrt(pow(radius, 2) + pow(this->CTPointSpreadFunctionSigma, 2));
 
           this->Stencil->SetRadius(radius);
         }
@@ -163,7 +163,7 @@ cipParticlesToStenciledLabelMapImageFilter< TInputImage >
       if ( this->ScaleStencilPatternByParticleScale )
         {
         double scale = this->ParticlesData->GetPointData()->GetArray("scale")->GetTuple(i)[0];
-        double tempRadius = vcl_sqrt(2.0)*vcl_sqrt( pow( scale, 2 ) + pow( this->CTPointSpreadFunctionSigma, 2 ) );
+        double tempRadius = std::sqrt(2.0)*std::sqrt( pow( scale, 2 ) + pow( this->CTPointSpreadFunctionSigma, 2 ) );
 
         this->Stencil->SetRadius( tempRadius );
         }
@@ -171,7 +171,7 @@ cipParticlesToStenciledLabelMapImageFilter< TInputImage >
       if ( this->DNNRadiusName != "" )
        {
         double radius = this->ParticlesData->GetPointData()->GetArray(this->DNNRadiusName.c_str())->GetTuple(i)[0];
-        double tempRadius = vcl_sqrt(2.0) * vcl_sqrt(pow(radius, 2) + pow(this->CTPointSpreadFunctionSigma, 2));
+        double tempRadius = std::sqrt(2.0) * std::sqrt(pow(radius, 2) + pow(this->CTPointSpreadFunctionSigma, 2));
 
         this->Stencil->SetRadius(tempRadius);
         }

--- a/Common/cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric.cxx
+++ b/Common/cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric.cxx
@@ -90,7 +90,7 @@ double cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric::GetValue( cons
 	      // locations of the points (the x and y coordinates) remain
 	      // fixed 
 	      this->RightObliqueSurfacePoints[p][2] += 
-		(*params)[m]*vcl_sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
+		(*params)[m]*std::sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
 	    }
 	}
       else
@@ -104,7 +104,7 @@ double cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric::GetValue( cons
 	      // locations of the points (the x and y coordinates) remain
 	      // fixed 
 	      this->RightHorizontalSurfacePoints[index][2] += 
-		(*params)[m]*vcl_sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
+		(*params)[m]*std::sqrt(this->Eigenvalues[m])*this->Eigenvectors[m][p];
 	    }
 	}
     }
@@ -193,8 +193,8 @@ double cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric::GetFissureTerm
     // Get the distances between the particle and the TPS surfaces. This
     // is just the square root of the objective function value
     // optimized by the Newton method.
-    double roDistance = vcl_sqrt( this->RightObliqueNewtonOptimizer.GetOptimalValue() );
-    double rhDistance = vcl_sqrt( this->RightHorizontalNewtonOptimizer.GetOptimalValue() );
+    double roDistance = std::sqrt( this->RightObliqueNewtonOptimizer.GetOptimalValue() );
+    double rhDistance = std::sqrt( this->RightHorizontalNewtonOptimizer.GetOptimalValue() );
 
     // Get the TPS surface normals at the domain locations.
     this->RightObliqueNewtonOptimizer.GetMetric().GetThinPlateSplineSurface().
@@ -292,8 +292,8 @@ double cipRightLobesThinPlateSplineSurfaceModelToParticlesMetric::GetVesselTermV
     // Get the distances between the particle and the TPS surfaces. This
     // is just the square root of the objective function value
     // optimized by the Newton method.
-    double roDistance = vcl_sqrt( this->RightObliqueNewtonOptimizer.GetOptimalValue() );
-    double rhDistance = vcl_sqrt( this->RightHorizontalNewtonOptimizer.GetOptimalValue() );
+    double roDistance = std::sqrt( this->RightObliqueNewtonOptimizer.GetOptimalValue() );
+    double rhDistance = std::sqrt( this->RightHorizontalNewtonOptimizer.GetOptimalValue() );
 
     // Get the TPS surface normals at the domain locations.
     this->RightObliqueNewtonOptimizer.GetMetric().GetThinPlateSplineSurface().

--- a/Common/cipThinPlateSplineSurface.cxx
+++ b/Common/cipThinPlateSplineSurface.cxx
@@ -96,7 +96,7 @@ void cipThinPlateSplineSurface::ComputeThinPlateSplineVectors()
       double x2 = this->m_SurfacePoints[j][0];
       double y2 = this->m_SurfacePoints[j][1];
 
-      double r = vcl_sqrt( (x1-x2)*(x1-x2) + (y1-y2)*(y1-y2) );
+      double r = std::sqrt( (x1-x2)*(x1-x2) + (y1-y2)*(y1-y2) );
       rTotal += r;
 
       if ( i == j )
@@ -111,7 +111,7 @@ void cipThinPlateSplineSurface::ComputeThinPlateSplineVectors()
 	  }
 	else
 	  {
-	  K[i][j] = r*r*vcl_log10( r );
+	  K[i][j] = r*r*std::log10( r );
 	  }
         }
       }
@@ -236,11 +236,11 @@ double cipThinPlateSplineSurface::GetSurfaceHeight( double x, double y ) const
     double x2 = this->m_SurfacePoints[n][0];
     double y2 = this->m_SurfacePoints[n][1];
     
-    double r = vcl_sqrt( (x-x2)*(x-x2)+(y-y2)*(y-y2) );
+    double r = std::sqrt( (x-x2)*(x-x2)+(y-y2)*(y-y2) );
 
     if ( r!=0 )
       {
-      total += this->m_w[n]*r*r*vcl_log10( r );
+      total += this->m_w[n]*r*r*std::log10( r );
       }
     }
   double z = this->m_a[0] + x*this->m_a[1] + y*this->m_a[2] + total;
@@ -253,7 +253,7 @@ void cipThinPlateSplineSurface::GetSurfaceNormal( double x, double y, cip::Vecto
 {
   this->GetNonNormalizedSurfaceNormal( x, y, normal );
 
-  double mag = vcl_sqrt( std::pow( normal[0], 2 ) + std::pow( normal[1], 2 ) + std::pow( normal[2], 2 ) );
+  double mag = std::sqrt( std::pow( normal[0], 2 ) + std::pow( normal[1], 2 ) + std::pow( normal[2], 2 ) );
 
   normal[0] = normal[0]/mag;
   normal[1] = normal[1]/mag;
@@ -277,9 +277,9 @@ void cipThinPlateSplineSurface::GetNonNormalizedSurfaceNormal( double x, double 
     double xDiff = x - this->m_SurfacePoints[i][0];
     double yDiff = y - this->m_SurfacePoints[i][1];
 
-    double r = vcl_sqrt( std::pow( xDiff, 2 ) + std::pow( yDiff, 2 ) );
+    double r = std::sqrt( std::pow( xDiff, 2 ) + std::pow( yDiff, 2 ) );
 
-    double dUdr = r*(2.0*vcl_log10( r ) + 1.0/vnl_math::ln10);
+    double dUdr = r*(2.0*std::log10( r ) + 1.0/vnl_math::ln10);
     double drdx = xDiff/r;
     double drdy = yDiff/r;
 
@@ -310,7 +310,7 @@ double cipThinPlateSplineSurface::GetBendingEnergy() const
       double x2 = this->m_SurfacePoints[j][0];
       double y2 = this->m_SurfacePoints[j][1];
 
-      double r = vcl_sqrt( (x1-x2)*(x1-x2) + (y1-y2)*(y1-y2) );
+      double r = std::sqrt( (x1-x2)*(x1-x2) + (y1-y2)*(y1-y2) );
 
       if ( r==0 )
         {
@@ -332,7 +332,7 @@ double cipThinPlateSplineSurface::GetBendingEnergy() const
         }
       else
         {
-        K[i][j] = r*r*vcl_log10( r );
+        K[i][j] = r*r*std::log10( r );
         }
       }
     }

--- a/Common/cipVesselParticleConnectedComponentFilter.cxx
+++ b/Common/cipVesselParticleConnectedComponentFilter.cxx
@@ -68,7 +68,7 @@ bool cipVesselParticleConnectedComponentFilter::EvaluateParticleConnectedness( u
 
   double maxScale;  (scale1>scale2) ? (maxScale = scale1) : (maxScale = scale2);
 
-  if ( vcl_abs(scale1 - scale2)/maxScale > this->ScaleRatioThreshold )
+  if ( std::abs(scale1 - scale2)/maxScale > this->ScaleRatioThreshold )
     {
     return false;
     }

--- a/Common/itkCIPAutoThresholdAirwaySegmentationImageFilter.h
+++ b/Common/itkCIPAutoThresholdAirwaySegmentationImageFilter.h
@@ -87,7 +87,7 @@ public:
    * growing */
   void AddSeed( typename TOutputImage::IndexType );
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
   typedef itk::Image< LabelMapPixelType, 3 >                                             LabelMapType;
@@ -101,7 +101,7 @@ protected:
   CIPAutoThresholdAirwaySegmentationImageFilter();
   virtual ~CIPAutoThresholdAirwaySegmentationImageFilter() {}
 
-  void GenerateData();
+  void GenerateData() override;
   void Test();
 
 private:

--- a/Common/itkCIPDijkstraImageToGraphFunctor.h
+++ b/Common/itkCIPDijkstraImageToGraphFunctor.h
@@ -79,10 +79,10 @@ public:
   typedef std::vector<IndexType> IndexContainerType;
 
   /** define virtual functions */
-  virtual EdgeWeightType GetEdgeWeight( IndexType, IndexType );
-  virtual NodeWeightType GetNodeWeight( IndexType idx );
-  virtual bool IsPixelANode( IndexType idx );
-  virtual void NormalizeGraph( NodeImageType *, OutputGraphType * );
+  virtual EdgeWeightType GetEdgeWeight( IndexType, IndexType ) override;
+  virtual NodeWeightType GetNodeWeight( IndexType idx ) override;
+  virtual bool IsPixelANode( IndexType idx ) override;
+  virtual void NormalizeGraph( NodeImageType *, OutputGraphType * ) override;
 
   bool IsAnEdge( IndexType, IndexType );
 
@@ -150,7 +150,7 @@ public:
 protected:
   CIPDijkstraImageToGraphFunctor();
   ~CIPDijkstraImageToGraphFunctor() {}
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 private:
   CIPDijkstraImageToGraphFunctor( const Self& ); //purposely not implemented

--- a/Common/itkCIPDijkstraImageToGraphFunctor.txx
+++ b/Common/itkCIPDijkstraImageToGraphFunctor.txx
@@ -52,11 +52,11 @@ CIPDijkstraImageToGraphFunctor<TInputImage, TOutputGraph>
     }
   else if ( this->m_ExponentialBasedCostAssignment )
     {
-    nodeWeight = this->m_ExponentialCoefficient*vcl_exp( pixelValue/this->m_ExponentialTimeConstant );
+    nodeWeight = this->m_ExponentialCoefficient*std::exp( pixelValue/this->m_ExponentialTimeConstant );
     }
   else
     {
-    nodeWeight = this->m_SigmoidScale/( 1.0 + vcl_exp( -this->m_SigmoidSteepness*( pixelValue - this->m_SigmoidShift ) ) );
+    nodeWeight = this->m_SigmoidScale/( 1.0 + std::exp( -this->m_SigmoidSteepness*( pixelValue - this->m_SigmoidShift ) ) );
     }
 
   return static_cast< NodeWeightType >( nodeWeight );

--- a/Common/itkCIPDijkstraMinCostPathGraphToGraphFilter.h
+++ b/Common/itkCIPDijkstraMinCostPathGraphToGraphFilter.h
@@ -58,7 +58,7 @@ protected:
   CIPDijkstraMinCostPathGraphToGraphFilter();
   ~CIPDijkstraMinCostPathGraphToGraphFilter() {};
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   CIPDijkstraMinCostPathGraphToGraphFilter( const Self& ); //purposely not implemented

--- a/Common/itkCIPExtractChestLabelMapImageFilter.h
+++ b/Common/itkCIPExtractChestLabelMapImageFilter.h
@@ -83,7 +83,7 @@ public:
   typedef itk::ImageRegionIteratorWithIndex< OutputImageType > OutputIteratorType;
   typedef itk::ImageRegionConstIterator< InputImageType >      InputIteratorType;
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
   /** This method allows the user to specify region-type pairs.  Only
    *  those input image values satisfying both the specified
@@ -115,7 +115,7 @@ protected:
   CIPExtractChestLabelMapImageFilter();
   //virtual ~CIPExtractChestLabelMapImageFilter() {}
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   CIPExtractChestLabelMapImageFilter(const Self&); //purposely not implemented

--- a/Common/itkCIPLabelLungRegionsImageFilter.h
+++ b/Common/itkCIPLabelLungRegionsImageFilter.h
@@ -118,7 +118,7 @@ public:
   itkGetConstReferenceMacro( LabelLungThirds, bool );
   itkBooleanMacro( LabelLungThirds );
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
   typedef Image< LabelMapPixelType, 3 >                                     LabelMapType;
@@ -134,7 +134,7 @@ protected:
 
   bool LabelLeftAndRightLungs();
   void SetLungThirds();
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   CIPLabelLungRegionsImageFilter(const Self&); //purposely not implemented

--- a/Common/itkCIPMergeChestLabelMapsImageFilter.h
+++ b/Common/itkCIPMergeChestLabelMapsImageFilter.h
@@ -201,14 +201,14 @@ public:
    *  image. **/
   void SetOverlayImage( cip::LabelMapType::Pointer, cip::LabelMapType::IndexType );
     
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
 
   CIPMergeChestLabelMapsImageFilter();
   virtual ~CIPMergeChestLabelMapsImageFilter() {}
 
-  void GenerateData();
+  void GenerateData() override;
 
   void MergeOverlay();
   void GraftOverlay();

--- a/Common/itkCIPOtsuLungCastImageFilter.h
+++ b/Common/itkCIPOtsuLungCastImageFilter.h
@@ -50,7 +50,7 @@ public:
   typedef typename OutputImageType::RegionType         OutputImageRegionType;
   typedef typename InputImageType::SizeType            InputSizeType;
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
   typedef itk::Image< unsigned short, 3 >                                                ComponentImageType;
@@ -74,7 +74,7 @@ protected:
       contain the lung region, a situation that we don't handle) */
   void RemoveCornerObjects();
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   CIPOtsuLungCastImageFilter(const Self&); //purposely not implemented

--- a/Common/itkCIPPartialLungLabelMapImageFilter.h
+++ b/Common/itkCIPPartialLungLabelMapImageFilter.h
@@ -133,7 +133,7 @@ public:
    */
   void SetHelperMask( OutputImageType::Pointer );
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
   typedef itk::Image< unsigned short, 3 >                                                      ComponentImageType;
@@ -163,7 +163,7 @@ protected:
   CIPPartialLungLabelMapImageFilter();
   virtual ~CIPPartialLungLabelMapImageFilter() {}
 
-  void GenerateData();
+  void GenerateData() override;
   void ApplyHelperMask();
   void ExtractLabelMapSlice( LabelMapType::Pointer, LabelMapSliceType::Pointer, int );
   void CloseLabelMap( unsigned short );

--- a/Common/itkCIPPartialLungLabelMapImageFilter.txx
+++ b/Common/itkCIPPartialLungLabelMapImageFilter.txx
@@ -606,7 +606,7 @@ CIPPartialLungLabelMapImageFilter< TInputImage >
       std::map< unsigned int, unsigned short >::iterator mapIt = xCentroidMap.begin();
       while ( mapIt != xCentroidMap.end() )
         {
-        int diff = vcl_abs( int((*mapIt).first) - int(middleLocation) );
+        int diff = std::abs( int((*mapIt).first) - int(middleLocation) );
 
         if ( diff < minDiff )
           {                                     

--- a/Common/itkCIPSplitLeftLungRightLungImageFilter.h
+++ b/Common/itkCIPSplitLeftLungRightLungImageFilter.h
@@ -87,7 +87,7 @@ public:
 
   void SetLungLabelMap( LabelMapType::Pointer );
 
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 protected:
   typedef itk::Image< LabelMapPixelType, 2 >         LabelMapSliceType;
@@ -130,7 +130,7 @@ protected:
   /** */
   void SetLocalGraphROIAndSearchIndices( unsigned int );
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   CIPSplitLeftLungRightLungImageFilter(const Self&); //purposely not implemented

--- a/Common/itkCIPWholeLungVesselAndAirwaySegmentationImageFilter.txx
+++ b/Common/itkCIPWholeLungVesselAndAirwaySegmentationImageFilter.txx
@@ -536,7 +536,7 @@ CIPWholeLungVesselAndAirwaySegmentationImageFilter< TInputImage >
       std::map< unsigned int, unsigned short >::iterator mapIt = xCentroidMap.begin();
       while ( mapIt != xCentroidMap.end() )
         {
-        int diff = vcl_abs( static_cast< int >( (*mapIt).first ) - static_cast< int >( middleLocation ) );
+        int diff = std::abs( static_cast< int >( (*mapIt).first ) - static_cast< int >( middleLocation ) );
 
         if ( diff < minDiff )
           {                                     

--- a/Common/vtkComputeAirwayWall.h
+++ b/Common/vtkComputeAirwayWall.h
@@ -38,7 +38,7 @@ class VTK_CIP_COMMON_EXPORT vtkComputeAirwayWall : public vtkImageAlgorithm
 public:
   static vtkComputeAirwayWall *New();
   vtkTypeMacro(vtkComputeAirwayWall, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetMacro(Method,int);
   vtkGetMacro(Method,int);
@@ -150,10 +150,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   double FindValue(vtkDoubleArray *c, int loc, double target);
   void FindZeros(vtkDoubleArray *c, vtkDoubleArray *cp, vtkDoubleArray *cpp, vtkDoubleArray *zeros);

--- a/Common/vtkComputeAirwayWallPolyData.h
+++ b/Common/vtkComputeAirwayWallPolyData.h
@@ -40,7 +40,7 @@ class VTK_CIP_COMMON_EXPORT vtkComputeAirwayWallPolyData : public vtkPolyDataAlg
 public:
   static vtkComputeAirwayWallPolyData *New();
   vtkTypeMacro(vtkComputeAirwayWallPolyData, vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   // Description:
   // Set/Get Image data
@@ -122,7 +122,7 @@ protected:
   // Usual data generation method
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
   //void ExecuteInformation();
   void ComputeCellData();
   int AxisMode;

--- a/Common/vtkComputeCentroid.h
+++ b/Common/vtkComputeCentroid.h
@@ -38,7 +38,7 @@ class VTK_CIP_COMMON_EXPORT vtkComputeCentroid : public vtkImageAlgorithm
 public:
   static vtkComputeCentroid *New();
   vtkTypeMacro(vtkComputeCentroid, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Get Image Centroid
@@ -52,10 +52,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   void ComputeCentroid(vtkImageData *in, int ext[6], double C[3]);
   void ComputeCentroid();

--- a/Common/vtkComputeMonogenicSignal.h
+++ b/Common/vtkComputeMonogenicSignal.h
@@ -36,7 +36,7 @@ class VTK_CIP_COMMON_EXPORT vtkComputeMonogenicSignal : public vtkImageAlgorithm
 public:
   static vtkComputeMonogenicSignal *New();
   vtkTypeMacro(vtkComputeMonogenicSignal, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetObjectMacro(QuadratureFilter,vtkGeneralizedQuadratureKernelSource);
   vtkGetObjectMacro(QuadratureFilter,vtkGeneralizedQuadratureKernelSource);
@@ -60,10 +60,10 @@ protected:
   // Use RequestData instead of ExecuteDataWithInformation when input data is needed
   virtual int RequestData(vtkInformation* request, 
                           vtkInformationVector** inputVector, 
-                          vtkInformationVector* outputVector); 
+                          vtkInformationVector* outputVector) override;
                                           
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   void FillOutput(vtkImageData *out, vtkImageData *in, int comp);
 

--- a/Common/vtkEllipseFitting.cxx
+++ b/Common/vtkEllipseFitting.cxx
@@ -185,7 +185,7 @@ int vtkEllipseFitting::RequestData(vtkInformation* vtkNotUsed(request),
   double a[6];
 
   vnl_real_eigensystem solver(mMat);
-  vnl_matrix<vcl_complex<double> > vMat = solver.V;
+  vnl_matrix<std::complex<double> > vMat = solver.V;
   for (int i=0; i<3; i++)
     for (int j=0; j<3; j++)
       v[i][j]=vMat(i,j).real();

--- a/Common/vtkEllipseFitting.h
+++ b/Common/vtkEllipseFitting.h
@@ -18,7 +18,7 @@ class VTK_CIP_COMMON_EXPORT vtkEllipseFitting : public vtkPolyDataAlgorithm
 {
 public:
   static vtkEllipseFitting *New();
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkTypeMacro(vtkEllipseFitting, vtkPolyDataAlgorithm);
 
   vtkGetMacro(MajorAxisLength,double);
@@ -46,9 +46,9 @@ protected:
   // Usual data generation method
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
   void MultiplyMatrix(double A1[3][3], double A2[3][3], double R[3][3]);
 
 private:

--- a/Common/vtkExtractAirwayTree.cxx
+++ b/Common/vtkExtractAirwayTree.cxx
@@ -866,7 +866,7 @@ double vtkExtractAirwayTree::ScaleSelection(gageContext *gtx, gagePerVolume *pvl
     if (prevV > 0)
       Sopt = Sopt2;
 
-  delete strength;
+  delete[] strength;
   return Sopt;
 }
 

--- a/Common/vtkExtractAirwayTree.h
+++ b/Common/vtkExtractAirwayTree.h
@@ -98,7 +98,7 @@ class VTK_CIP_COMMON_EXPORT vtkExtractAirwayTree : public vtkPolyDataAlgorithm
 public:
   static vtkExtractAirwayTree *New();
   vtkTypeMacro(vtkExtractAirwayTree, vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetVector3Macro(Seed,double);
   vtkGetVector3Macro(Seed,double);
@@ -178,10 +178,10 @@ protected:
   vtkExtractAirwayTree();
   ~vtkExtractAirwayTree();
 
-  virtual int FillInputPortInformation(int port, vtkInformation *info);
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
   int SettingContextAndState(gageContext *gtx,gagePerVolume *pvl,vtkTrackingState *state,double scale);
 
   double Seed[3];

--- a/Common/vtkGeneralizedPhaseCongruency.h
+++ b/Common/vtkGeneralizedPhaseCongruency.h
@@ -37,7 +37,7 @@ class VTK_CIP_COMMON_EXPORT vtkGeneralizedPhaseCongruency : public vtkImageAlgor
 public:
   static vtkGeneralizedPhaseCongruency *New();
   vtkTypeMacro(vtkGeneralizedPhaseCongruency, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetMacro(NumberOfScales,int);
   vtkGetMacro(NumberOfScales,int);
@@ -78,10 +78,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
                                           
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   void FillOutput(vtkImageData *out, vtkImageData *in, int comp);
 

--- a/Common/vtkGeneralizedQuadratureKernelSource.h
+++ b/Common/vtkGeneralizedQuadratureKernelSource.h
@@ -18,7 +18,7 @@ class VTK_CIP_COMMON_EXPORT vtkGeneralizedQuadratureKernelSource : public vtkIma
 public:
   static vtkGeneralizedQuadratureKernelSource *New();
   vtkTypeMacro(vtkGeneralizedQuadratureKernelSource, vtkImageKernelSource);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Center frequency where the filter gives the
@@ -76,7 +76,7 @@ public:
 
   void ThreadedExecute(vtkImageData *inData,
                        vtkImageData *outData,
-                       int outExt[6], int id);
+                       int outExt[6], int id) override;
 protected:
   vtkGeneralizedQuadratureKernelSource();
   ~vtkGeneralizedQuadratureKernelSource() {};
@@ -100,10 +100,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
                                          
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 };
 
 #endif

--- a/Common/vtkImageKernel.h
+++ b/Common/vtkImageKernel.h
@@ -19,7 +19,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageKernel : public vtkImageData
 public:
   static vtkImageKernel *New();
   vtkTypeMacro(vtkImageKernel, vtkImageData);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Create a similar type object
@@ -27,7 +27,7 @@ public:
 
   // Description:
   // To simplify filter superclasses,
-  int GetDataObjectType() {return VTK_IMAGE_DATA;}
+  int GetDataObjectType() override {return VTK_IMAGE_DATA;}
 
   // Description:
   // Whether the kernel is located in the
@@ -89,8 +89,8 @@ public:
 
   // Description:
   // Shallow and Deep copy.
-  void ShallowCopy(vtkDataObject *src);
-  void DeepCopy(vtkDataObject *src);
+  void ShallowCopy(vtkDataObject *src) override;
+  void DeepCopy(vtkDataObject *src) override;
 
 protected:
   vtkImageKernel();

--- a/Common/vtkImageKernelSource.h
+++ b/Common/vtkImageKernelSource.h
@@ -18,7 +18,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageKernelSource : public vtkImageAlgorithm
 public:
   static vtkImageKernelSource *New();
   vtkTypeMacro(vtkImageKernelSource, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Get the output of this source.
@@ -144,12 +144,12 @@ protected:
   int ComplexOutput;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
                                  
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
 private:
   vtkImageKernelSource(const vtkImageKernelSource&);
   void operator=(const vtkImageKernelSource&);

--- a/Common/vtkImageReformatAlongRay.h
+++ b/Common/vtkImageReformatAlongRay.h
@@ -38,7 +38,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageReformatAlongRay : public vtkImageAlgorithm
 public:
   static vtkImageReformatAlongRay *New();
   vtkTypeMacro(vtkImageReformatAlongRay, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   vtkSetMacro(Theta,double);
   vtkGetMacro(Theta,double);
@@ -76,13 +76,13 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   virtual int RequestUpdateExtent(vtkInformation *, vtkInformationVector **,
-                                  vtkInformationVector *);
+                                  vtkInformationVector *) override;
 
   double Theta;
   double RMin;

--- a/Common/vtkImageReformatAlongRay2.h
+++ b/Common/vtkImageReformatAlongRay2.h
@@ -41,7 +41,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageReformatAlongRay2 : public vtkImageAlgorithm
 public:
   static vtkImageReformatAlongRay2 *New();
   vtkTypeMacro(vtkImageReformatAlongRay2, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   //Description:
   //Tanget of the ray
@@ -97,10 +97,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
                                           
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
   void ComputeTangentFromNormal();
 
   double Theta;

--- a/Common/vtkImageResliceWithPlane.h
+++ b/Common/vtkImageResliceWithPlane.h
@@ -40,7 +40,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageResliceWithPlane : public vtkImageAlgorithm
 public:
   static vtkImageResliceWithPlane *New();
   vtkTypeMacro(vtkImageResliceWithPlane, vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Get right Centroid of the lung
   vtkSetVector3Macro(Dimensions,int);
@@ -100,10 +100,10 @@ protected:
   // This is a convenience method that is implemented in many subclasses
   // instead of RequestData.  It is called by RequestData.
   virtual void ExecuteDataWithInformation(vtkDataObject *output,
-                                          vtkInformation* outInfo);
+                                          vtkInformation* outInfo) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   int ComputeAxes;
   int ComputeCenter;

--- a/Common/vtkImageStatistics.h
+++ b/Common/vtkImageStatistics.h
@@ -32,7 +32,7 @@ class VTK_CIP_COMMON_EXPORT vtkImageStatistics : public vtkImageAlgorithm
   public:
   static vtkImageStatistics *New();
   vtkTypeMacro(vtkImageStatistics,vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Should the data with value 0 be ignored?
@@ -98,11 +98,11 @@ class VTK_CIP_COMMON_EXPORT vtkImageStatistics : public vtkImageAlgorithm
   // convenience method
   virtual int RequestInformation(vtkInformation* request,
                                  vtkInformationVector** inputVector,
-                                 vtkInformationVector* outputVector);
+                                 vtkInformationVector* outputVector) override;
 
  virtual int RequestData(vtkInformation *,
                           vtkInformationVector **,
-                          vtkInformationVector *);
+                          vtkInformationVector *) override;
 
 };
 

--- a/Common/vtkImageTubularConfidence.h
+++ b/Common/vtkImageTubularConfidence.h
@@ -88,9 +88,9 @@ protected:
   ~vtkImageTubularConfidence();
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-                       int extent[6], int id);
+                       int extent[6], int id) override;
                        
   int TubularType;
   vtkImageData *Mask;

--- a/Common/vtkLungIntensityCorrection.h
+++ b/Common/vtkLungIntensityCorrection.h
@@ -43,7 +43,7 @@ class VTK_CIP_COMMON_EXPORT vtkLungIntensityCorrection : public vtkThreadedImage
 public:
   static vtkLungIntensityCorrection *New();
   vtkTypeMacro(vtkLungIntensityCorrection, vtkThreadedImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Specify the stencil to use.  The stencil can be created
@@ -109,12 +109,12 @@ protected:
   vtkLungIntensityCorrection();
   ~vtkLungIntensityCorrection();
   
-  virtual int FillInputPortInformation(int, vtkInformation*);
+  virtual int FillInputPortInformation(int, vtkInformation*) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-                       int extent[6], int id);
+                       int extent[6], int id) override;
 
   int ReverseStencil;
   int ClampNegativeValues;

--- a/Common/vtkMultipleReconstructionKernelsPhaseCongruency.h
+++ b/Common/vtkMultipleReconstructionKernelsPhaseCongruency.h
@@ -35,7 +35,7 @@ class VTK_CIP_COMMON_EXPORT vtkMultipleReconstructionKernelsPhaseCongruency : pu
 public:
   static vtkMultipleReconstructionKernelsPhaseCongruency *New();
   vtkTypeMacro(vtkMultipleReconstructionKernelsPhaseCongruency, vtkThreadedImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Set a stencil to apply when blending the data.
@@ -54,21 +54,21 @@ public:
                                    vtkInformationVector *outputVector,
                                    vtkImageData ***inData,
                                    vtkImageData **outData,
-                                   int extent[6], int threadId);
+                                   int extent[6], int threadId) override;
 
 protected:
   vtkMultipleReconstructionKernelsPhaseCongruency();
   ~vtkMultipleReconstructionKernelsPhaseCongruency();
 
-  virtual int FillInputPortInformation(int, vtkInformation*);
+  virtual int FillInputPortInformation(int, vtkInformation*) override;
 
   virtual int RequestInformation(vtkInformation *, vtkInformationVector**,
-                                 vtkInformationVector *);
+                                 vtkInformationVector *) override;
 
   // This is called by the superclass.
   virtual int RequestData(vtkInformation* request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
 
   // Description:                                                         
   // Keep the old signature for the sake of simplicity.

--- a/Common/vtkNRRDExport.h
+++ b/Common/vtkNRRDExport.h
@@ -44,7 +44,7 @@ class VTK_CIP_COMMON_EXPORT vtkNRRDExport : public vtkAlgorithm
 public:
   static vtkNRRDExport *New();
   vtkTypeMacro(vtkNRRDExport, vtkAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Set/Get the input object from the image pipeline.

--- a/Common/vtkSimpleLungMask.h
+++ b/Common/vtkSimpleLungMask.h
@@ -25,7 +25,7 @@ class VTK_CIP_COMMON_EXPORT vtkSimpleLungMask : public vtkImageAlgorithm
 public:
   static vtkSimpleLungMask *New();
   vtkTypeMacro(vtkSimpleLungMask,vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Get left Centroid of the lung
@@ -80,7 +80,7 @@ protected:
   vtkSimpleLungMask();
   ~vtkSimpleLungMask();
 
-  void ExecuteDataWithInformation(vtkDataObject *, vtkInformation *);
+  void ExecuteDataWithInformation(vtkDataObject *, vtkInformation *) override;
 
   void ComputeCentroids(vtkImageData *in, int LC[3], int RC[3]);
   void ComputeCentroid(vtkImageData *in, int ext[6], int C[3]);

--- a/Common/vtkSmoothLines.h
+++ b/Common/vtkSmoothLines.h
@@ -19,7 +19,7 @@ class VTK_CIP_COMMON_EXPORT vtkSmoothLines : public vtkPolyDataAlgorithm
 {
 public:
   static vtkSmoothLines *New();
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkTypeMacro(vtkSmoothLines,vtkPolyDataAlgorithm);
 
   vtkGetMacro(Beta,double);
@@ -43,7 +43,7 @@ protected:
   // Usual data generation method
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
 private:
   vtkSmoothLines(const vtkSmoothLines&);  // Not implemented.
   void operator=(const vtkSmoothLines&);  // Not implemented.

--- a/Common/vtkTubularScalePolyDataFilter.h
+++ b/Common/vtkTubularScalePolyDataFilter.h
@@ -20,7 +20,7 @@ class VTK_CIP_COMMON_EXPORT vtkTubularScalePolyDataFilter : public vtkPolyDataAl
 {
 public:
   static vtkTubularScalePolyDataFilter *New();
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   vtkTypeMacro(vtkTubularScalePolyDataFilter, vtkPolyDataAlgorithm);
 
    // Description: Type of tubular structure that we want to capture. Valleys are dark tubes (i.e. airways). Ridges are bright tubes (i.e. vessels)
@@ -52,7 +52,7 @@ protected:
   // Usual data generation method
   virtual int RequestData(vtkInformation *request,
                           vtkInformationVector** inputVector,
-                          vtkInformationVector* outputVector);
+                          vtkInformationVector* outputVector) override;
                           
   int TubularType;
   vtkImageData *ImageData;

--- a/Common/vtkTubularScaleSelection.cxx
+++ b/Common/vtkTubularScaleSelection.cxx
@@ -358,7 +358,7 @@ double vtkTubularScaleSelection::ScaleSelection(gageContext **gtx, gagePerVolume
   if (prevV > 0)
     Sopt = Sopt2;
 
-  delete strength;
+  delete[] strength;
 
   return Sopt;
 }
@@ -456,7 +456,7 @@ double vtkTubularScaleSelection::ScaleSelection(gageContext *gtx, gagePerVolume 
   if (prevV > 0)
     Sopt = Sopt2;
 
-  delete strength;
+  delete[] strength;
 
   return Sopt;
 }

--- a/Common/vtkTubularScaleSelection.h
+++ b/Common/vtkTubularScaleSelection.h
@@ -39,7 +39,7 @@ class VTK_CIP_COMMON_EXPORT vtkTubularScaleSelection : public vtkThreadedImageAl
 public:
   static vtkTubularScaleSelection *New();
   vtkTypeMacro(vtkTubularScaleSelection, vtkThreadedImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   // Description: Mask (short image) where the tubular confidence map will be computed.
   vtkSetObjectMacro(Mask,vtkImageData);
   vtkGetObjectMacro(Mask,vtkImageData);
@@ -78,10 +78,10 @@ protected:
   ~vtkTubularScaleSelection();
 
   virtual int RequestInformation (vtkInformation *, vtkInformationVector**,
-                                  vtkInformationVector *);
+                                  vtkInformationVector *) override;
 
   void ThreadedExecute (vtkImageData *inData, vtkImageData *outData,
-                        int outExt[6], int id);
+                        int outExt[6], int id) override;
 
   int TubularType;
   vtkImageData *Mask;

--- a/Utilities/GraphCutsOptimization/energy.h
+++ b/Utilities/GraphCutsOptimization/energy.h
@@ -259,9 +259,9 @@ inline void Energy<captype,tcaptype,flowtype>::add_term3(Var x, Var y, Var z,
                               Value E100, Value E101,
                               Value E110, Value E111)
 {
-	register Value pi = (E000 + E011 + E101 + E110) - (E100 + E010 + E001 + E111);
-	register Value delta;
-	register Var u;
+	Value pi = (E000 + E011 + E101 + E110) - (E100 + E010 + E001 + E111);
+	Value delta;
+	Var u;
 
 	if (pi >= 0)
 	{

--- a/Utilities/GraphCutsOptimization/maxflow.cpp
+++ b/Utilities/GraphCutsOptimization/maxflow.cpp
@@ -363,7 +363,7 @@ template <typename captype, typename tcaptype, typename flowtype>
 		}
 	}
 
-	if (i->parent = a0_min)
+	if ((i->parent = a0_min) != nullptr)
 	{
 		i -> TS = TIME;
 		i -> DIST = d_min + 1;
@@ -440,7 +440,7 @@ template <typename captype, typename tcaptype, typename flowtype>
 		}
 	}
 
-	if (i->parent = a0_min)
+	if ((i->parent = a0_min) != nullptr)
 	{
 		i -> TS = TIME;
 		i -> DIST = d_min + 1;

--- a/Utilities/ITK/itkBinaryFunctorImageFilter2.h
+++ b/Utilities/ITK/itkBinaryFunctorImageFilter2.h
@@ -160,11 +160,11 @@ protected:
    *     ImageToImageFilter::GenerateData()  */
   virtual void ThreadedGenerateData(
     const OutputImageRegionType & outputRegionForThread,
-    ThreadIdType threadId );
+    ThreadIdType threadId ) override;
 
   // needed to take the image information from the 2nd input, if the first one is
   // a simple decorated object
-  virtual void GenerateOutputInformation( void );
+  virtual void GenerateOutputInformation( void ) override;
 
 private:
   BinaryFunctorImageFilter2(const Self &); // purposely not implemented

--- a/Utilities/ITK/itkBinaryThinningImageFilter3D.h
+++ b/Utilities/ITK/itkBinaryThinningImageFilter3D.h
@@ -122,10 +122,10 @@ public:
 protected:
   BinaryThinningImageFilter3D();
   virtual ~BinaryThinningImageFilter3D() {};
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Compute thinning Image. */
-  void GenerateData();
+  void GenerateData() override;
 
   /** Prepare data. */
   void PrepareData();

--- a/Utilities/ITK/itkComparisonOperators.h
+++ b/Utilities/ITK/itkComparisonOperators.h
@@ -19,8 +19,6 @@
 #define __itkComparisonOperators_h
 
 #include <algorithm>
-#include "vnl/vnl_math.h"
-
 
 namespace itk
 {
@@ -41,7 +39,7 @@ class AbsLessEqualCompare
 public:
   bool operator()( T a, T b )
   {
-    return vnl_math_abs( a ) <= vnl_math_abs( b );
+    return std::fabs( a ) <= std::fabs( b );
   }
 };
 
@@ -58,7 +56,7 @@ class AbsLessCompare
 public:
   bool operator()( T a, T b )
   {
-    return vnl_math_abs( a ) < vnl_math_abs( b );
+    return std::fabs( a ) < std::fabs( b );
   }
 };
 

--- a/Utilities/ITK/itkDefaultImageToGraphFunctor.h
+++ b/Utilities/ITK/itkDefaultImageToGraphFunctor.h
@@ -166,7 +166,7 @@ public:
 protected:
   ImageToGraphFunctor();
   ~ImageToGraphFunctor() {}
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
   unsigned int GetNeighborhoodIndex( const OffsetType &o ) const;
   void ComputeNeighborhoodStrideTable();
@@ -220,19 +220,19 @@ public:
   typedef typename Superclass::EdgeIdentifierContainerType
                                                     EdgeIdentifierContainerType;
 
-  virtual bool IsPixelANode(IndexType idx)
+  virtual bool IsPixelANode(IndexType idx) override
     { return ( !this->m_ExcludeBackground ||
       ( this->GetInput()->GetPixel( idx ) != this->m_BackgroundValue ) ); }
-  virtual EdgeWeightType GetEdgeWeight(IndexType idx1, IndexType idx2 )
+  virtual EdgeWeightType GetEdgeWeight(IndexType idx1, IndexType idx2 ) override
       { return ( static_cast<EdgeWeightType>( 1 ) ); }
-  virtual NodeWeightType GetNodeWeight( IndexType idx )
+  virtual NodeWeightType GetNodeWeight( IndexType idx ) override
       { return ( static_cast<NodeWeightType>( 1 ) ); }
-  virtual void NormalizeGraph( NodeImageType *im, OutputGraphType *g ) {}
+  virtual void NormalizeGraph( NodeImageType *im, OutputGraphType *g ) override {}
 
 protected:
   DefaultImageToGraphFunctor() {}
   ~DefaultImageToGraphFunctor() {}
-  void PrintSelf(std::ostream& os, Indent indent) const
+  void PrintSelf(std::ostream& os, Indent indent) const override
      { Superclass::PrintSelf( os, indent ); }
 
 private:

--- a/Utilities/ITK/itkDescoteauxSheetnessFunctor.h
+++ b/Utilities/ITK/itkDescoteauxSheetnessFunctor.h
@@ -20,7 +20,6 @@
 
 #include "itkUnaryFunctorBase.h"
 #include "itkComparisonOperators.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -65,7 +64,7 @@ public:
   typedef typename EigenValueArrayType::ValueType   EigenValueType;
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput & eigenValues ) const
+  virtual TOutput Evaluate( const TInput & eigenValues ) const override
   {
     /** Sort the eigenvalues by their absolute value, such that |l1| < |l2| < |l3|. */
     EigenValueArrayType sortedEigenValues = eigenValues;
@@ -73,9 +72,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::fabs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::fabs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::fabs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )
@@ -96,21 +95,21 @@ public:
     }
 
     /** Avoid divisions by zero (or close to zero). */
-    if( l3 < vnl_math::eps )
+    if( l3 < itk::Math::eps )
     {
       return NumericTraits<TOutput>::Zero;
     }
 
     /** Compute several structure measures. */
     const RealType Rsheet = l2 / l3;
-    const RealType Rblob  = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
-    const RealType Rnoise = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
+    const RealType Rblob  = std::fabs( l3 + l3 - l2 - l1 ) / l3;
+    const RealType Rnoise = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute final sheetness measure, see Eq.(13). */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Rsheet * Rsheet ) / ( 2.0 * this->m_Alpha * this->m_Alpha ) ); // sheetness vs lineness
+    sheetness *= ( 1.0 - std::exp( - ( Rblob  * Rblob )  / ( 2.0 * this->m_Beta * this->m_Beta ) ) ); // blobness
+    sheetness *= ( 1.0 - std::exp( - ( Rnoise * Rnoise ) / ( 2.0 * this->m_C * this->m_C ) ) );       // noise = structuredness
 
     return static_cast<TOutput>( sheetness );
   } // end operator ()

--- a/Utilities/ITK/itkFrangiSheetnessFunctor.h
+++ b/Utilities/ITK/itkFrangiSheetnessFunctor.h
@@ -20,7 +20,6 @@
 
 #include "itkUnaryFunctorBase.h"
 #include "itkComparisonOperators.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -68,7 +67,7 @@ public:
   typedef typename EigenValueArrayType::ValueType   EigenValueType;
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput & eigenValues ) const
+  virtual TOutput Evaluate( const TInput & eigenValues ) const override
   {
     /** Sort the eigenvalues by their absolute value, such that |l1| < |l2| < |l3|. */
     EigenValueArrayType sortedEigenValues = eigenValues;
@@ -76,9 +75,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::fabs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::fabs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::fabs( sortedEigenValues[ 2 ] );
 
     const RealType eigenValuesSum = eigenValues[ 0 ]
       + eigenValues[ 1 ] + eigenValues[ 2 ];
@@ -100,21 +99,21 @@ public:
     }
 
     /** Avoid divisions by zero (or close to zero). */
-    if( l2 < vnl_math::eps || l3 < vnl_math::eps )
+    if( l2 < itk::Math::eps || l3 < itk::Math::eps )
     {
       return NumericTraits<TOutput>::Zero;
     }
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3;
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 );
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
+    const RealType Rb = l1 / std::sqrt( l2 * l3 );
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 );
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
-    sheetness *=         vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
+    sheetness *=         std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
+    sheetness *= ( 1.0 - std::exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
 
     return static_cast<TOutput>( sheetness );
   } // end operator ()

--- a/Utilities/ITK/itkFrangiVesselnessFunctor.h
+++ b/Utilities/ITK/itkFrangiVesselnessFunctor.h
@@ -20,7 +20,6 @@
 
 #include "itkUnaryFunctorBase.h"
 #include "itkComparisonOperators.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -67,7 +66,7 @@ public:
   typedef typename EigenValueArrayType::ValueType   EigenValueType;
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput & eigenValues ) const
+  virtual TOutput Evaluate( const TInput & eigenValues ) const override
   {
     /** Sort the eigenvalues by their absolute value, such that |l1| < |l2| < |l3|. */
     EigenValueArrayType sortedEigenValues = eigenValues;
@@ -75,9 +74,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::fabs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::fabs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::fabs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )
@@ -98,21 +97,21 @@ public:
     }
 
     /** Avoid divisions by zero (or close to zero). */
-    if( l2 < vnl_math::eps || l3 < vnl_math::eps )
+    if( l2 < itk::Math::eps || l3 < itk::Math::eps )
     {
       return NumericTraits<TOutput>::Zero;
     }
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3; // see Eq.(11)
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 ); // see Eq.(10)
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
+    const RealType Rb = l1 / std::sqrt( l2 * l3 ); // see Eq.(10)
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
 
     /** Compute final vesselness measure, see Eq.(13). */
     RealType vesselness = NumericTraits<RealType>::Zero;
-    vesselness  = ( 1.0 - vcl_exp( -( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); // sheetness vs lineness
-    vesselness *=         vcl_exp( -( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) );   // blobness
-    vesselness *= ( 1.0 - vcl_exp( -( S  * S )  / ( 2.0 * m_C     * m_C ) ) );     // noise = structuredness
+    vesselness  = ( 1.0 - std::exp( -( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); // sheetness vs lineness
+    vesselness *=         std::exp( -( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) );   // blobness
+    vesselness *= ( 1.0 - std::exp( -( S  * S )  / ( 2.0 * m_C     * m_C ) ) );     // noise = structuredness
 
     return static_cast<TOutput>( vesselness );
   } // end operator ()

--- a/Utilities/ITK/itkFrangiXiaoSheetnessFunctor.h
+++ b/Utilities/ITK/itkFrangiXiaoSheetnessFunctor.h
@@ -20,7 +20,6 @@
 
 #include "itkBinaryFunctorBase.h"
 #include "itkComparisonOperators.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -81,7 +80,7 @@ public:
   typedef typename EigenValueArrayType::ValueType   EigenValueType;
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput1 & gMag, const TInput2 & eigenValues ) const
+  virtual TOutput Evaluate( const TInput1 & gMag, const TInput2 & eigenValues ) const override
   {
     /** Sort the eigenvalues by their absolute value, such that |l1| < |l2| < |l3|. */
     EigenValueArrayType sortedEigenValues = eigenValues;
@@ -89,9 +88,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::fabs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::fabs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::fabs( sortedEigenValues[ 2 ] );
 
     const RealType gradientMagnitude = static_cast<RealType>( gMag ) ;
     const RealType eigenValuesSum = eigenValues[ 0 ]
@@ -114,26 +113,26 @@ public:
     }
 
     /** Avoid divisions by zero (or close to zero). */
-    if( l2 < vnl_math::eps || l3 < vnl_math::eps )
+    if( l2 < itk::Math::eps || l3 < itk::Math::eps )
     {
       return NumericTraits<TOutput>::Zero;
     }
 
     /** Compute several structure measures. */
     const RealType Ra = l2 / l3; // see Eq.(11)
-    const RealType Rb = l1 / vcl_sqrt( l2 * l3 ); // see Eq.(10)
-    const RealType S  = vcl_sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
+    const RealType Rb = l1 / std::sqrt( l2 * l3 ); // see Eq.(10)
+    const RealType S  = std::sqrt( l1 * l1 + l2 * l2 + l3 * l3 ); // see Eq.(12)
 
     /** Compute Frangi sheetness measure. */
     RealType sheetness = NumericTraits<RealType>::Zero;
-    sheetness  =         vcl_exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
-    sheetness *=         vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
-    sheetness *= ( 1.0 - vcl_exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
+    sheetness  =         std::exp( - ( Ra * Ra ) / ( 2.0 * m_Alpha * m_Alpha ) ); // sheetness vs lineness
+    sheetness *=         std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta * m_Beta ) );   // blobness
+    sheetness *= ( 1.0 - std::exp( - ( S  * S  ) / ( 2.0 * m_C * m_C ) ) );       // noise = structuredness
 
     // Step-edge suppressing proposed by Changyan Xiao
     // Dividing by S or l3 does not make much difference
-    //sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / S ) );
-    sheetness *= vcl_exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
+    //sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / S ) );
+    sheetness *= std::exp( -1.0 * m_Kappa * ( gradientMagnitude / l3 ) );
 
     return static_cast<TOutput>( sheetness );
   } // end Evaluate()

--- a/Utilities/ITK/itkGaussianEnhancementImageFilter.h
+++ b/Utilities/ITK/itkGaussianEnhancementImageFilter.h
@@ -153,8 +153,8 @@ protected:
   GaussianEnhancementImageFilter();
   virtual ~GaussianEnhancementImageFilter() {};
 
-  virtual void PrintSelf(std::ostream& os, Indent indent) const;
-  virtual void GenerateData( void );
+  virtual void PrintSelf(std::ostream& os, Indent indent) const override;
+  virtual void GenerateData( void ) override;
 
 private:
   GaussianEnhancementImageFilter(const Self&); //purposely not implemented

--- a/Utilities/ITK/itkGraph.h
+++ b/Utilities/ITK/itkGraph.h
@@ -295,7 +295,7 @@ protected:
   /** Constructor for use by New() method. */
   Graph();
   ~Graph();
-  virtual void PrintSelf( std::ostream& os, Indent indent ) const;
+  virtual void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 private:
   Graph( const Self& ); //purposely not implemented

--- a/Utilities/ITK/itkGraphSource.h
+++ b/Utilities/ITK/itkGraphSource.h
@@ -122,12 +122,12 @@ public:
 protected:
   GraphSource();
   virtual ~GraphSource() {}
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
 
   /** Requested region of Graph is specified as i of N unstructured regions.
    * Since all DataObjects should be able to set the requested region in
    * unstructured form, just copy output->RequestedRegion all inputs. */
-  void GenerateInputRequestedRegion();
+  void GenerateInputRequestedRegion() override;
 
 private:
   GraphSource( const Self& ); //purposely not implemented

--- a/Utilities/ITK/itkImageToGraphFilter.h
+++ b/Utilities/ITK/itkImageToGraphFilter.h
@@ -50,7 +50,7 @@ public:
   itkTypeMacro( ImageToGraphFilter, GraphSource );
 
   /** Create a valid output. */
-  DataObject::Pointer  MakeOutput( unsigned int idx );
+  DataObject::Pointer  MakeOutput( unsigned int idx ) override;
 
   /** Some Image related typedefs. */
   typedef   TInputImage                        ImageType;
@@ -93,14 +93,14 @@ public:
   itkSetObjectMacro( ImageToGraphFunctor, ImageToGraphFunctorType );
 
   /** Prepare the output */
-  void GenerateOutputInformation( void );
+  void GenerateOutputInformation( void ) override;
 
 protected:
   ImageToGraphFilter();
   ~ImageToGraphFilter();
-  void PrintSelf( std::ostream& os, Indent indent ) const;
+  void PrintSelf( std::ostream& os, Indent indent ) const override;
   
-  void GenerateData();
+  void GenerateData() override;
  
 private:
   ImageToGraphFilter( const ImageToGraphFilter& ); //purposely not implemented

--- a/Utilities/ITK/itkLSDerivatives.h
+++ b/Utilities/ITK/itkLSDerivatives.h
@@ -90,11 +90,11 @@ protected:
     void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, int threadId );
     
 #else
-    void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId );
+    void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId ) override;
     
 #endif
-	void BeforeThreadedGenerateData();
-	void GenerateInputRequestedRegion();
+	void BeforeThreadedGenerateData() override;
+	void GenerateInputRequestedRegion() override;
 private:
 	LSDerivativesL0(const Self&);   // purposely not implemented
 	void operator=(const Self&);    // purposely not implemented
@@ -150,11 +150,11 @@ private:
         void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, int threadId );
         
 #else
-        void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId );
+        void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId ) override;
         
 #endif
-		void BeforeThreadedGenerateData();
-		void GenerateInputRequestedRegion();
+		void BeforeThreadedGenerateData() override;
+		void GenerateInputRequestedRegion() override;
 	private:
 		LSDerivativesL1(const Self&);   // purposely not implemented
 		void operator=(const Self&);    // purposely not implemented
@@ -210,11 +210,11 @@ private:
         void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, int threadId );
         
 #else
-        void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId );
+        void ThreadedGenerateData( const OutputRegionType& outputRegionForThread, ThreadIdType threadId ) override;
         
 #endif
-		void BeforeThreadedGenerateData();
-		void GenerateInputRequestedRegion();
+		void BeforeThreadedGenerateData() override;
+		void GenerateInputRequestedRegion() override;
 	private:
 		LSDerivativesL2(const Self&);   // purposely not implemented
 		void operator=(const Self&);    // purposely not implemented

--- a/Utilities/ITK/itkModifiedKrissianVesselnessFunctor.h
+++ b/Utilities/ITK/itkModifiedKrissianVesselnessFunctor.h
@@ -20,7 +20,6 @@
 
 #include "itkUnaryFunctorBase.h"
 #include "itkComparisonOperators.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -64,7 +63,7 @@ public:
   typedef typename EigenValueArrayType::ValueType   EigenValueType;
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput & eigenValues ) const
+  virtual TOutput Evaluate( const TInput & eigenValues ) const override
   {
     /** Sort the eigenvalues by their absolute value, such that |l1| < |l2| < |l3|. */
     EigenValueArrayType sortedEigenValues = eigenValues;
@@ -72,9 +71,9 @@ public:
       Functor::AbsLessCompare<EigenValueType>() );
 
     /** Take the absolute values and abbreviate. */
-    const RealType l1 = vnl_math_abs( sortedEigenValues[ 0 ] );
-    const RealType l2 = vnl_math_abs( sortedEigenValues[ 1 ] );
-    const RealType l3 = vnl_math_abs( sortedEigenValues[ 2 ] );
+    const RealType l1 = std::fabs( sortedEigenValues[ 0 ] );
+    const RealType l2 = std::fabs( sortedEigenValues[ 1 ] );
+    const RealType l3 = std::fabs( sortedEigenValues[ 2 ] );
 
     /** Reject. */
     if( this->m_BrightObject )
@@ -95,7 +94,7 @@ public:
     }
 
     /** Avoid divisions by zero (or close to zero). */
-    if( l3 < vnl_math::eps )
+    if( l3 < itk::Math::eps )
     {
       return NumericTraits<TOutput>::Zero;
     }

--- a/Utilities/ITK/itkMultiScaleGaussianEnhancementImageFilter.h
+++ b/Utilities/ITK/itkMultiScaleGaussianEnhancementImageFilter.h
@@ -181,7 +181,7 @@ public:
   /** This is overloaded to create the Scales and Hessian output images */
   virtual DataObjectPointer MakeOutput( unsigned int idx );
 
-  void EnlargeOutputRequestedRegion( DataObject * );
+  void EnlargeOutputRequestedRegion( DataObject * ) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -195,10 +195,10 @@ protected:
   ~MultiScaleGaussianEnhancementImageFilter() {};
 
   /** Does the work. */
-  virtual void GenerateData( void );
+  virtual void GenerateData( void ) override;
 
   /** Print member variables. */
-  virtual void PrintSelf( std::ostream& os, Indent indent ) const;
+  virtual void PrintSelf( std::ostream& os, Indent indent ) const override;
 
 private:
   MultiScaleGaussianEnhancementImageFilter(const Self&); // purposely not implemented

--- a/Utilities/ITK/itkMultiScaleGaussianEnhancementImageFilter.hxx
+++ b/Utilities/ITK/itkMultiScaleGaussianEnhancementImageFilter.hxx
@@ -288,17 +288,17 @@ MultiScaleGaussianEnhancementImageFilter< TInputImage, TOutputImage >
   {
   case Self::EquispacedSigmaSteps:
     {
-      const double stepSize = vnl_math_max( 1e-10,
+      const double stepSize = std::max( 1e-10,
         ( this->m_SigmaMaximum - this->m_SigmaMinimum ) / ( this->m_NumberOfSigmaSteps - 1 ) );
       sigmaValue = this->m_SigmaMinimum + stepSize * scaleLevel;
       break;
     }
   case Self::LogarithmicSigmaSteps:
     {
-      const double stepSize = vnl_math_max( 1e-10,
-        ( vcl_log( this->m_SigmaMaximum ) - vcl_log( this->m_SigmaMinimum ) )
+      const double stepSize = std::max( 1e-10,
+        ( std::log( this->m_SigmaMaximum ) - std::log( this->m_SigmaMinimum ) )
         / ( this->m_NumberOfSigmaSteps - 1 ) );
-      sigmaValue = vcl_exp( vcl_log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
+      sigmaValue = std::exp( std::log ( this->m_SigmaMinimum ) + stepSize * scaleLevel );
       break;
     }
   default:

--- a/Utilities/ITK/itkPFNLMFilter.h
+++ b/Utilities/ITK/itkPFNLMFilter.h
@@ -92,12 +92,12 @@ protected:
     void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, int threadId );
     
 #else
-    void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId );
+    void ThreadedGenerateData( const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId ) override;
     
 #endif
-	void GenerateInputRequestedRegion();
-	void BeforeThreadedGenerateData( void );
-	void PrintSelf( std::ostream &os, Indent indent ) const;
+	void GenerateInputRequestedRegion() override;
+	void BeforeThreadedGenerateData( void ) override;
+	void PrintSelf( std::ostream &os, Indent indent ) const override;
 private:
 	PFNLMFilter(const Self&);         // purposely not implemented
 	void operator=(const Self&);    // purposely not implemented

--- a/Utilities/ITK/itkStrainEnergySheetnessFunctor.h
+++ b/Utilities/ITK/itkStrainEnergySheetnessFunctor.h
@@ -19,7 +19,6 @@
 #define __itkStrainEnergySheetnessFunctor_h
 
 #include "itkBinaryFunctorBase.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -69,7 +68,7 @@ public:
   itkStaticConstMacro( Dimension, unsigned int, TInput2::Dimension );
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput1 & gMag, const TInput2 & eigenValues ) const
+  virtual TOutput Evaluate( const TInput1 & gMag, const TInput2 & eigenValues ) const override
   {
     // Final strain energy sheetness
     RealType SES = NumericTraits<RealType>::Zero; // set the initial output value to 0.0
@@ -83,7 +82,7 @@ public:
     for ( unsigned int i = 0; i < Dimension; ++i )
     {
       RealType tmp1 = eigenValues[ i ];
-      RealType tmp2 = vnl_math_abs( tmp1 );
+      RealType tmp2 = itk::Math::abs( tmp1 );
       if ( maxEvMag < tmp2 )
       {
         maxEvMag = tmp2;
@@ -102,20 +101,20 @@ public:
       RealType HA2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        H2 += vnl_math_sqr( eigenValues[ i ] );
-        HA2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        H2 += itk::Math::sqr( eigenValues[ i ] );
+        HA2 += itk::Math::sqr( eigenValues[ i ] - mLamda );
       }
 
-      const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
+      const RealType HI2 = 3.0 * itk::Math::sqr( mLamda );
 
       // Compute the strain energy function, see Eq.(18)
-      const RealType SE = vcl_sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
+      const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
         + ( 1.0 + this->m_Nu ) * HA2 );
 
       // Compute the FA, see Eq.(26)
       RealType FA2 = NumericTraits<RealType>::Zero;
       FA2 = HA2 / H2;
-      const RealType FA = vcl_sqrt( 3.0 * FA2 );
+      const RealType FA = std::sqrt( 3.0 * FA2 );
 
       // Calculate the mode, see Eq.(27)
       RealType tm1 = NumericTraits<RealType>::Zero;
@@ -123,11 +122,11 @@ public:
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
         tm1 += std::pow( eigenValues[ i ] - mLamda, static_cast<int>(Dimension) );
-        tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        tm2 += itk::Math::sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
       tm2 = std::pow( tm2 / 3.0, 1.5 );
-      RealType mode = vcl_sqrt( 2.0 ) * tm1 / tm2;
+      RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the S(x), see Eq.(28)
       // Needs work
@@ -142,7 +141,7 @@ public:
       }
 
       // Relative Hessian strength, see Eq.(25)
-      const RealType edgeW = vcl_exp( -this->m_Beta * gMag / maxEvMag );
+      const RealType edgeW = std::exp( -this->m_Beta * gMag / maxEvMag );
 
       // Integrate the above terms to form the final sheet-tuned strain energy density, see Eq.(29)
       SES *= edgeW * SE;

--- a/Utilities/ITK/itkStrainEnergyVesselnessFunctor.h
+++ b/Utilities/ITK/itkStrainEnergyVesselnessFunctor.h
@@ -19,7 +19,6 @@
 #define __itkStrainEnergyVesselnessFunctor_h
 
 #include "itkBinaryFunctorBase.h"
-#include "vnl/vnl_math.h"
 
 namespace itk
 {
@@ -69,7 +68,7 @@ public:
   itkStaticConstMacro( Dimension, unsigned int, TInput2::Dimension );
 
   /** This does the real computation */
-  virtual TOutput Evaluate( const TInput1 & _gradientMagnitude, const TInput2 & _eigenValues ) const
+  virtual TOutput Evaluate( const TInput1 & _gradientMagnitude, const TInput2 & _eigenValues ) const override
   {
     // Strain energy vesselness
     RealType SEV = NumericTraits<RealType>::Zero; // set the initial output value to 0.0
@@ -91,7 +90,7 @@ public:
     for ( unsigned int i = 0; i < Dimension; ++i )
     {
       RealType tmp1 = eigenValues[ i ];
-      RealType tmp2 = vnl_math_abs( tmp1 );
+      RealType tmp2 = std::fabs( tmp1 );
       if ( maxEvMag < tmp2 )
       {
         maxEvMag = tmp2;
@@ -121,20 +120,20 @@ public:
       RealType HA2 = NumericTraits<RealType>::Zero;
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
-        H2 += vnl_math_sqr( eigenValues[ i ] );
-        HA2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        H2 += itk::Math::sqr( eigenValues[ i ] );
+        HA2 += itk::Math::sqr( eigenValues[ i ] - mLamda );
       }
 
-      const RealType HI2 = 3.0 * vnl_math_sqr( mLamda );
+      const RealType HI2 = 3.0 * itk::Math::sqr( mLamda );
 
       // Compute the strain energy density, see Eq.(20)
-      const RealType SE = vcl_sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
+      const RealType SE = std::sqrt( ( 1.0 - 2.0 * this->m_Nu ) * HI2
         + ( 1.0 + this->m_Nu ) * HA2 );
 
       // Compute the FA, see Eq.(28)
       RealType FA2 = NumericTraits<RealType>::Zero;
       FA2 = HA2 / H2;
-      const RealType FA = vcl_sqrt( 3.0 * FA2 );
+      const RealType FA = std::sqrt( 3.0 * FA2 );
 
       // Calculate the mode(x), see Eq.(29)
       RealType tm1 = NumericTraits<RealType>::Zero;
@@ -142,11 +141,11 @@ public:
       for ( unsigned int i = 0; i < Dimension; ++i )
       {
         tm1 += std::pow( eigenValues[ i ] - mLamda, static_cast<int>(Dimension) );
-        tm2 += vnl_math_sqr( eigenValues[ i ] - mLamda );
+        tm2 += itk::Math::sqr( eigenValues[ i ] - mLamda );
       }
       tm1 /= Dimension;
       tm2 = std::pow( tm2 / 3.0, 1.5 );
-      const RealType mode = vcl_sqrt( 2.0 ) * tm1 / tm2;
+      const RealType mode = std::sqrt( 2.0 ) * tm1 / tm2;
 
       // Combine FA and mode to generate the pow(V(x),k), see Eq.(30)
       if ( FA > NumericTraits<RealType>::One )
@@ -160,7 +159,7 @@ public:
       }
 
       // Relative Hessian strength function, see Eq.(27)
-      const RealType edgeW = vcl_exp( -this->m_Beta * gradientMagnitude / maxEvMag );
+      const RealType edgeW = std::exp( -this->m_Beta * gradientMagnitude / maxEvMag );
 
       // Integrate the above terms to form the final vessel-tuned strain energy density, see Eq.(31)
       SEV *= edgeW * SE;

--- a/Utilities/ITK/itkUnaryFunctorImageFilter2.h
+++ b/Utilities/ITK/itkUnaryFunctorImageFilter2.h
@@ -93,7 +93,7 @@ protected:
    * below.
    *
    * \sa ProcessObject::GenerateOutputInformaton()  */
-  virtual void GenerateOutputInformation( void );
+  virtual void GenerateOutputInformation( void ) override;
 
   /** UnaryFunctorImageFilter can be implemented as a multithreaded filter.
    * Therefore, this implementation provides a ThreadedGenerateData() routine
@@ -107,7 +107,7 @@ protected:
    *     ImageToImageFilter::GenerateData()  */
   virtual void ThreadedGenerateData(
     const OutputImageRegionType & outputRegionForThread,
-    ThreadIdType threadId );
+    ThreadIdType threadId ) override;
 
 private:
   UnaryFunctorImageFilter2(const Self &); // purposely not implemented

--- a/Utilities/ITKStrain/itkSplitComponentsImageFilter.h
+++ b/Utilities/ITKStrain/itkSplitComponentsImageFilter.h
@@ -88,11 +88,11 @@ protected:
   virtual ~SplitComponentsImageFilter() {}
 
   /** Do not allocate outputs that we will not populate. */
-  virtual void AllocateOutputs();
+  virtual void AllocateOutputs() override;
 
-  virtual void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId );
+  virtual void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
 
-  virtual void PrintSelf ( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+  virtual void PrintSelf ( std::ostream& os, Indent indent ) const  override;
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -193,7 +193,7 @@ public:
    * pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */  
-  virtual void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError);
+  virtual void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -213,9 +213,9 @@ public:
 protected:
   CannyEdgeDetectionRecursiveGaussianImageFilter();
   CannyEdgeDetectionRecursiveGaussianImageFilter(const Self&) {}
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
-  void GenerateData();
+  void GenerateData() override;
 
   typedef MultiplyImageFilter< OutputImageType, 
               OutputImageType, OutputImageType>       MultiplyImageFilterType;

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -302,7 +302,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
     str->Filter->ThreadedCompute2ndDerivative(splitRegion, threadId);
     }
 
-  return ITK_THREAD_RETURN_VALUE;
+  return nullptr;
 }
 
 template< class TInputImage, class TOutputImage >
@@ -568,7 +568,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
                     m_ComputeCannyEdge1stDerivativeOper);
         }
       
-      gradMag = vcl_sqrt((double)gradMag);
+      gradMag = std::sqrt((double)gradMag);
       derivPos = zero;
       for ( unsigned int i = 0; i < ImageDimension; i++)
         {
@@ -635,7 +635,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
     str->Filter->ThreadedCompute2ndDerivativePos( splitRegion, threadId);
     }
   
-  return ITK_THREAD_RETURN_VALUE;
+  return nullptr;
 }
 
 // Set value of Sigma (isotropic)

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.hxx
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.hxx
@@ -581,7 +581,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter< TInputImage, TOutputImage >
                     m_ComputeCannyEdge1stDerivativeOper);
         }
       
-      gradMag = vcl_sqrt((double)gradMag);
+      gradMag = std::sqrt((double)gradMag);
       derivPos = zero;
       for ( unsigned int i = 0; i < ImageDimension; i++)
         {

--- a/Utilities/LesionSizingToolkit/itkCannyEdgesFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgesFeatureGenerator.h
@@ -112,11 +112,11 @@ public:
 protected:
   CannyEdgesFeatureGenerator();
   virtual ~CannyEdgesFeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   CannyEdgesFeatureGenerator(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkDescoteauxSheetnessImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkDescoteauxSheetnessImageFilter.h
@@ -133,11 +133,11 @@ public:
 
     const double Rs = l2 / l3;
     const double Rb = vnl_math_abs( l3 + l3 - l2 - l1 ) / l3;
-    const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
+    const double Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    sheetness  =         vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ); 
-    sheetness *= ( 1.0 - vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
-    sheetness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) ); 
+    sheetness  =         std::exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ); 
+    sheetness *= ( 1.0 - std::exp( - ( Rb * Rb ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
+    sheetness *= ( 1.0 - std::exp( - ( Rn * Rn ) / ( 2.0 * m_C     * m_C     ) ) ); 
 
     return static_cast<TOutput>( sheetness );
     }

--- a/Utilities/LesionSizingToolkit/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/Utilities/LesionSizingToolkit/itkFastMarchingAndGeodesicActiveContourLevelSetSegmentationModule.h
@@ -87,11 +87,11 @@ public:
 protected:
   FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule();
   virtual ~FastMarchingAndGeodesicActiveContourLevelSetSegmentationModule();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
   typedef  FastMarchingSegmentationModule< Dimension > FastMarchingModuleType;
   typename FastMarchingModuleType::Pointer m_FastMarchingModule;

--- a/Utilities/LesionSizingToolkit/itkFastMarchingSegmentationModule.h
+++ b/Utilities/LesionSizingToolkit/itkFastMarchingSegmentationModule.h
@@ -84,11 +84,11 @@ public:
 protected:
   FastMarchingSegmentationModule();
   virtual ~FastMarchingSegmentationModule();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
   /** Extract the input set of landmark points to be used as seeds. */
   const InputSpatialObjectType * GetInternalInputLandmarks() const;

--- a/Utilities/LesionSizingToolkit/itkFastMarchingSegmentationModule.hxx
+++ b/Utilities/LesionSizingToolkit/itkFastMarchingSegmentationModule.hxx
@@ -99,7 +99,7 @@ FastMarchingSegmentationModule<NDimension>
 
   typedef typename InputSpatialObjectType::SpatialObjectPointType   SpatialObjectPointType;
   typedef typename SpatialObjectPointType::PointType                PointType;
-  typedef typename InputSpatialObjectType::PointListType            PointListType;
+  typedef typename InputSpatialObjectType::LandmarkPointListType    LandmarkPointListType;
   typedef typename FeatureImageType::IndexType                      IndexType;
   typedef typename FeatureImageType::IndexType                      IndexType;
   typedef typename FilterType::NodeContainer                        NodeContainer;
@@ -107,13 +107,13 @@ FastMarchingSegmentationModule<NDimension>
 
   typename NodeContainer::Pointer trialPoints = NodeContainer::New();
   
-  const PointListType & points = inputSeeds->GetPoints();
+  const LandmarkPointListType & points = inputSeeds->GetPoints();
 
   IndexType index;
 
   for( unsigned int i=0; i < numberOfPoints; i++ )
     {
-    featureImage->TransformPhysicalPointToIndex( points[i].GetPosition(), index );
+    featureImage->TransformPhysicalPointToIndex( points[i].GetPositionInWorldSpace(), index );
 
     NodeType node;
 

--- a/Utilities/LesionSizingToolkit/itkFeatureAggregator.h
+++ b/Utilities/LesionSizingToolkit/itkFeatureAggregator.h
@@ -76,16 +76,16 @@ public:
   void AddFeatureGenerator( FeatureGeneratorType * generator ); 
 
   /** Check all feature generators and return consolidate MTime */
-  virtual unsigned long GetMTime() const;
+  virtual unsigned long GetMTime() const override;
 
 protected:
   FeatureAggregator();
   virtual ~FeatureAggregator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData();
+  void  GenerateData() override;
 
   unsigned int GetNumberOfInputFeatures() const;
 

--- a/Utilities/LesionSizingToolkit/itkFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkFeatureGenerator.h
@@ -73,7 +73,7 @@ public:
 protected:
   FeatureGenerator();
   virtual ~FeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Derived classes must implement the "void  GenerateData()" method  */
 

--- a/Utilities/LesionSizingToolkit/itkFrangiTubularnessImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkFrangiTubularnessImageFilter.h
@@ -142,12 +142,12 @@ public:
       }
 
     const double Rs = l2 / l3;
-    const double Rb = l1 / vcl_sqrt( l2 * l3 );
-    const double Rn = vcl_sqrt( l3*l3 + l2*l2 + l1*l1 );
+    const double Rb = l1 / std::sqrt( l2 * l3 );
+    const double Rn = std::sqrt( l3*l3 + l2*l2 + l1*l1 );
 
-    tubularness  = ( 1.0 - vcl_exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); 
-    tubularness *= (       vcl_exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) ); 
-    tubularness *= ( 1.0 - vcl_exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
+    tubularness  = ( 1.0 - std::exp( - ( Rs * Rs ) / ( 2.0 * m_Alpha * m_Alpha ) ) ); 
+    tubularness *= (       std::exp( - ( Rb * Rb ) / ( 2.0 * m_Beta  * m_Beta  ) ) ); 
+    tubularness *= ( 1.0 - std::exp( - ( Rn * Rn ) / ( 2.0 * m_Gamma * m_Gamma ) ) ); 
 
     return static_cast<TOutput>( tubularness );
     }

--- a/Utilities/LesionSizingToolkit/itkGeodesicActiveContourLevelSetSegmentationModule.h
+++ b/Utilities/LesionSizingToolkit/itkGeodesicActiveContourLevelSetSegmentationModule.h
@@ -70,11 +70,11 @@ public:
 protected:
   GeodesicActiveContourLevelSetSegmentationModule();
   virtual ~GeodesicActiveContourLevelSetSegmentationModule();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   GeodesicActiveContourLevelSetSegmentationModule(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkIsotropicResamplerImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkIsotropicResamplerImageFilter.h
@@ -84,20 +84,20 @@ public:
 
   /** Override the superclass implementation so as to set the flag on all the
    * filters within our lesion segmentation pipeline */
-  virtual void SetAbortGenerateData( const bool );
+  virtual void SetAbortGenerateData( const bool ) override;
 
   /** ResampleImageFilter produces an image which is a different size
    * than its input.  As such, it needs to provide an implementation
    * for GenerateOutputInformation() in order to inform the pipeline
    * execution model.  The original documentation of this method is
    * below. \sa ProcessObject::GenerateOutputInformaton() */
-  virtual void GenerateOutputInformation( void );
+  virtual void GenerateOutputInformation( void ) override;
 
 protected:
   IsotropicResamplerImageFilter();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
-  void GenerateData();
+  void GenerateData() override;
 
 private:
   virtual ~IsotropicResamplerImageFilter();

--- a/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.h
+++ b/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.h
@@ -85,7 +85,7 @@ public:
   typedef typename CannyEdgesFeatureGeneratorType::SigmaArrayType SigmaArrayType;
 
   virtual void GenerateInputRequestedRegion()
-            throw(InvalidRequestedRegionError);
+            throw(InvalidRequestedRegionError) override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */
@@ -129,10 +129,10 @@ public:
   itkBooleanMacro( UseVesselEnhancingDiffusion );
 
   typedef itk::LandmarkSpatialObject< ImageDimension >    SeedSpatialObjectType;
-  typedef typename SeedSpatialObjectType::PointListType   PointListType;
+  typedef typename SeedSpatialObjectType::LandmarkPointListType   LandmarkPointListType;
 
-  void SetSeeds( PointListType p ) { this->m_Seeds = p; }
-  PointListType GetSeeds() { return m_Seeds; }
+  void SetSeeds( LandmarkPointListType p ) { this->m_Seeds = p; }
+  LandmarkPointListType GetSeeds() { return m_Seeds; }
 
   /** Report progress */
   void ProgressUpdate( Object * caller, const EventObject & event );
@@ -140,7 +140,7 @@ public:
   // Return the status message
   const char *GetStatusMessage() const
     {
-    return m_StatusMessage.length() ? m_StatusMessage.c_str() : NULL;
+    return m_StatusMessage.length() ? m_StatusMessage.c_str() : nullptr;
     }
 
   /* Manually specify sigma. This defaults to the max spacing in the dataset */
@@ -148,15 +148,15 @@ public:
 
   /** Override the superclass implementation so as to set the flag on all the
    * filters within our lesion segmentation pipeline */
-  virtual void SetAbortGenerateData( const bool );
+  virtual void SetAbortGenerateData( const bool ) override;
 
 protected:
   LesionSegmentationImageFilter8();
   LesionSegmentationImageFilter8(const Self&) {}
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
-  virtual void GenerateOutputInformation();
-  void GenerateData();
+  virtual void GenerateOutputInformation() override;
+  void GenerateData() override;
 
   // Filters used by this class
   typedef LesionSegmentationMethod< ImageDimension >                LesionSegmentationMethodType;
@@ -182,23 +182,23 @@ private:
   double                                m_FastMarchingStoppingTime;
   double                                m_FastMarchingDistanceFromSeeds;
 
-  typename LesionSegmentationMethodType::Pointer      m_LesionSegmentationMethod;
-  typename LungWallGeneratorType::Pointer             m_LungWallFeatureGenerator;
-  typename VesselnessGeneratorType::Pointer           m_VesselnessFeatureGenerator;
-  typename SigmoidFeatureGeneratorType::Pointer       m_SigmoidFeatureGenerator;
-  typename CannyEdgesFeatureGeneratorType::Pointer    m_CannyEdgesFeatureGenerator;
-  typename FeatureAggregatorType::Pointer             m_FeatureAggregator;
-  typename SegmentationModuleType::Pointer            m_SegmentationModule;
-  typename CropFilterType::Pointer                    m_CropFilter;
-  typename IsotropicResamplerType::Pointer            m_IsotropicResampler;
-  typename CommandType::Pointer                       m_CommandObserver;
-  RegionType                                          m_RegionOfInterest;
-  std::string                                         m_StatusMessage;
-  typename SeedSpatialObjectType::PointListType       m_Seeds;
-  typename InputImageSpatialObjectType::Pointer       m_InputSpatialObject;
-  bool                                                m_ResampleThickSliceData;
-  double                                              m_AnisotropyThreshold;
-  bool                                                m_UserSpecifiedSigmas;
+  typename LesionSegmentationMethodType::Pointer          m_LesionSegmentationMethod;
+  typename LungWallGeneratorType::Pointer                 m_LungWallFeatureGenerator;
+  typename VesselnessGeneratorType::Pointer               m_VesselnessFeatureGenerator;
+  typename SigmoidFeatureGeneratorType::Pointer           m_SigmoidFeatureGenerator;
+  typename CannyEdgesFeatureGeneratorType::Pointer        m_CannyEdgesFeatureGenerator;
+  typename FeatureAggregatorType::Pointer                 m_FeatureAggregator;
+  typename SegmentationModuleType::Pointer                m_SegmentationModule;
+  typename CropFilterType::Pointer                        m_CropFilter;
+  typename IsotropicResamplerType::Pointer                m_IsotropicResampler;
+  typename CommandType::Pointer                           m_CommandObserver;
+  RegionType                                              m_RegionOfInterest;
+  std::string                                             m_StatusMessage;
+  typename SeedSpatialObjectType::LandmarkPointListType   m_Seeds;
+  typename InputImageSpatialObjectType::Pointer           m_InputSpatialObject;
+  bool                                                    m_ResampleThickSliceData;
+  double                                                  m_AnisotropyThreshold;
+  bool                                                    m_UserSpecifiedSigmas;
 };
 
 } //end of namespace itk

--- a/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.hxx
+++ b/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.hxx
@@ -196,7 +196,7 @@ LesionSegmentationImageFilter8< TInputImage, TOutputImage >
   // Crop and perform thin slice resampling (done only if necessary)
   m_CropFilter->Update();
 
-  typename InputImageType::Pointer inputImage = NULL;
+  typename InputImageType::Pointer inputImage = nullptr;
   if (m_ResampleThickSliceData)
     {
     m_IsotropicResampler->Update();

--- a/Utilities/LesionSizingToolkit/itkLesionSegmentationMethod.h
+++ b/Utilities/LesionSizingToolkit/itkLesionSegmentationMethod.h
@@ -100,11 +100,11 @@ public:
 protected:
   LesionSegmentationMethod();
   virtual ~LesionSegmentationMethod();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData();
+  void  GenerateData() override;
 
 private:
   LesionSegmentationMethod(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkLocalStructureImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkLocalStructureImageFilter.h
@@ -127,12 +127,12 @@ public:
     {
     if( ls <= 0.0 && lt <= ls )
       {
-      return ( 1 + vcl_pow( ls / vnl_math_abs( lt ), m_Gamma ) );
+      return ( 1 + std::pow( ls / vnl_math_abs( lt ), m_Gamma ) );
       }
     const double abslt = vnl_math_abs( lt );
     if( ls > 0.0  &&  abslt / m_Gamma > ls )
       {
-      return vcl_pow( 1 - m_Alpha * ls / vnl_math_abs( lt ), m_Gamma );
+      return std::pow( 1 - m_Alpha * ls / vnl_math_abs( lt ), m_Gamma );
       }
     return 0.0;
     }
@@ -140,7 +140,7 @@ public:
     {
     if( ls < 0.0 && lt <= ls )
       {
-      return vcl_pow( ( ls / lt ), m_Gamma );
+      return std::pow( ( ls / lt ), m_Gamma );
       }
     return 0.0;
     }

--- a/Utilities/LesionSizingToolkit/itkLungWallFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkLungWallFeatureGenerator.h
@@ -82,11 +82,11 @@ public:
 protected:
   LungWallFeatureGenerator();
   virtual ~LungWallFeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   LungWallFeatureGenerator(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkMinimumFeatureAggregator.h
+++ b/Utilities/LesionSizingToolkit/itkMinimumFeatureAggregator.h
@@ -66,14 +66,14 @@ public:
 protected:
   MinimumFeatureAggregator();
   virtual ~MinimumFeatureAggregator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
 
 private:
   MinimumFeatureAggregator(const Self&); //purposely not implemented
   void operator=(const Self&); //purposely not implemented
 
-  void ConsolidateFeatures();
+  void ConsolidateFeatures() override;
 
 };
 

--- a/Utilities/LesionSizingToolkit/itkSatoVesselnessFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkSatoVesselnessFeatureGenerator.h
@@ -97,11 +97,11 @@ public:
 protected:
   SatoVesselnessFeatureGenerator();
   virtual ~SatoVesselnessFeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   SatoVesselnessFeatureGenerator(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkSatoVesselnessSigmoidFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkSatoVesselnessSigmoidFeatureGenerator.h
@@ -69,11 +69,11 @@ public:
 protected:
   SatoVesselnessSigmoidFeatureGenerator();
   virtual ~SatoVesselnessSigmoidFeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   SatoVesselnessSigmoidFeatureGenerator(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkSegmentationModule.h
+++ b/Utilities/LesionSizingToolkit/itkSegmentationModule.h
@@ -80,7 +80,7 @@ public:
 protected:
   SegmentationModule();
   virtual ~SegmentationModule();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /* Derived classes MUST implement the "void  GenerateData ()" method */
 

--- a/Utilities/LesionSizingToolkit/itkSigmoidFeatureGenerator.h
+++ b/Utilities/LesionSizingToolkit/itkSigmoidFeatureGenerator.h
@@ -86,11 +86,11 @@ public:
 protected:
   SigmoidFeatureGenerator();
   virtual ~SigmoidFeatureGenerator();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
 private:
   SigmoidFeatureGenerator(const Self&); //purposely not implemented

--- a/Utilities/LesionSizingToolkit/itkSinglePhaseLevelSetSegmentationModule.h
+++ b/Utilities/LesionSizingToolkit/itkSinglePhaseLevelSetSegmentationModule.h
@@ -106,11 +106,11 @@ public:
 protected:
   SinglePhaseLevelSetSegmentationModule();
   virtual ~SinglePhaseLevelSetSegmentationModule();
-  void PrintSelf(std::ostream& os, Indent indent) const;
+  void PrintSelf(std::ostream& os, Indent indent) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of
    * the segmentation. */
-  void  GenerateData ();
+  void  GenerateData () override;
 
   /** Set the output image as cargo of the output SpatialObject. */
   void PackOutputImageInOutputSpatialObject( OutputImageType * outputImage );

--- a/Utilities/LesionSizingToolkit/itkVesselEnhancingDiffusion3DImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkVesselEnhancingDiffusion3DImageFilter.h
@@ -138,8 +138,8 @@ public:
 protected:
   VesselEnhancingDiffusion3DImageFilter();
   ~VesselEnhancingDiffusion3DImageFilter() {};
-  void PrintSelf(std::ostream &os, Indent indent) const;
-  void GenerateData();
+  void PrintSelf(std::ostream &os, Indent indent) const override;
+  void GenerateData() override;
 
 private:
 

--- a/Utilities/LesionSizingToolkit/itkVesselEnhancingDiffusion3DImageFilter.hxx
+++ b/Utilities/LesionSizingToolkit/itkVesselEnhancingDiffusion3DImageFilter.hxx
@@ -521,9 +521,9 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
       ev[1] = ES.get_eigenvalue(1);
       ev[2] = ES.get_eigenvalue(2);
 
-      if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
-      if ( vcl_abs(ev[1]) > vcl_abs(ev[2])  ) std::swap(ev[1], ev[2]);
-      if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
+      if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
+      if ( std::abs(ev[1]) > std::abs(ev[2])  ) std::swap(ev[1], ev[2]);
+      if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
 
       const Precision vesselness = VesselnessFunction3D(ev[0],ev[1],ev[2]);
 
@@ -565,13 +565,13 @@ VesselEnhancingDiffusion3DImageFilter<PixelType,NDimension>
     const Precision vc2= 2.0*m_Gamma*m_Gamma;
 
     const Precision   Ra2 = (l2 * l2) / (l3 * l3);
-    const Precision   Rb2 = (l1 * l1) / vcl_abs(l2 * l3);
+    const Precision   Rb2 = (l1 * l1) / std::abs(l2 * l3);
     const Precision   S2 =  (l1 * l1) + (l2 *l2) + (l3 * l3);
-    const Precision   T = vcl_exp(-(2*smoothC*smoothC)/(vcl_abs(l2)*l3*l3));
+    const Precision   T = std::exp(-(2*smoothC*smoothC)/(std::abs(l2)*l3*l3));
 
-    vesselness = T * (1.0 - vcl_exp( - Ra2/va2)) *
-      vcl_exp(-Rb2/vb2) *
-      (1.0 - vcl_exp(-S2/vc2));
+    vesselness = T * (1.0 - std::exp( - Ra2/va2)) *
+      std::exp(-Rb2/vb2) *
+      (1.0 - std::exp(-S2/vc2));
 
     }
 
@@ -615,18 +615,18 @@ void VesselEnhancingDiffusion3DImageFilter<PixelType, NDimension>
     ev[1] = ES.get_eigenvalue(1);
     ev[2] = ES.get_eigenvalue(2);
 
-    if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
-    if ( vcl_abs(ev[1]) > vcl_abs(ev[2])  ) std::swap(ev[1], ev[2]);
-    if ( vcl_abs(ev[0]) > vcl_abs(ev[1])  ) std::swap(ev[0], ev[1]);
+    if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
+    if ( std::abs(ev[1]) > std::abs(ev[2])  ) std::swap(ev[1], ev[2]);
+    if ( std::abs(ev[0]) > std::abs(ev[1])  ) std::swap(ev[0], ev[1]);
 
     const Precision V=VesselnessFunction3D(ev[0],ev[1],ev[2]);
     vnl_vector<Precision> evn(3);
 
     // adjusting eigenvalues
     // static_cast required to prevent error with gcc 4.1.2
-    evn[0]   = 1.0 + (m_Epsilon - 1.0) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
-    evn[1]   = 1.0 + (m_Epsilon - 1.0) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
-    evn[2]   = 1.0 + (m_Omega - 1.0 ) * vcl_pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[0]   = 1.0 + (m_Epsilon - 1.0) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[1]   = 1.0 + (m_Epsilon - 1.0) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
+    evn[2]   = 1.0 + (m_Omega - 1.0 ) * std::pow(V,static_cast<Precision>(1.0/m_Sensitivity));
 
     vnl_matrix<Precision> LAM(3,3);
     LAM.fill(0);

--- a/Utilities/LesionSizingToolkit/itkVotingBinaryHoleFillFloodingImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkVotingBinaryHoleFillFloodingImageFilter.h
@@ -108,9 +108,9 @@ protected:
   VotingBinaryHoleFillFloodingImageFilter();
   ~VotingBinaryHoleFillFloodingImageFilter();
 
-  void GenerateData();
+  void GenerateData() override;
   
-  void PrintSelf ( std::ostream& os, Indent indent ) const;
+  void PrintSelf ( std::ostream& os, Indent indent ) const override;
 
 private:
   VotingBinaryHoleFillFloodingImageFilter(const Self&); //purposely not implemented

--- a/Utilities/VTK/vtkGlyph3DWithScaling.h
+++ b/Utilities/VTK/vtkGlyph3DWithScaling.h
@@ -98,7 +98,7 @@ class VTK_CIP_UTILITIES_EXPORT vtkGlyph3DWithScaling : public vtkPolyDataAlgorit
 {
 public:
   vtkTypeMacro(vtkGlyph3DWithScaling,vtkPolyDataAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description
   // Construct object with scaling on, scaling mode is by scalar value,
@@ -265,15 +265,15 @@ public:
 
   // Description:
   // Overridden to include SourceTransform's MTime.
-  virtual vtkMTimeType GetMTime();
+  virtual vtkMTimeType GetMTime() override;
 
 protected:
   vtkGlyph3DWithScaling();
   ~vtkGlyph3DWithScaling();
 
-  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
-  virtual int RequestUpdateExtent(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
-  virtual int FillInputPortInformation(int, vtkInformation *);
+  virtual int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+  virtual int RequestUpdateExtent(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+  virtual int FillInputPortInformation(int, vtkInformation *) override;
 
   vtkPolyData* GetSource(int idx, vtkInformationVector *sourceInfo);
 

--- a/Utilities/VTK/vtkImageConnectivity.cxx
+++ b/Utilities/VTK/vtkImageConnectivity.cxx
@@ -79,10 +79,10 @@ int connect(
      size_t *num_components) /* set to NULL if not interested */
 {
   unsigned int i;
-  register unsigned int axisv;
+  unsigned int axisv;
   size_t data_len;
-  register size_t label, *outimagep, *outimage_end, *imagep, *new_imagep, boundary_mask_start, component_mask, axis_mask;
-  register ptrdiff_t *stride, stridev;
+  size_t label, *outimagep, *outimage_end, *imagep, *new_imagep, boundary_mask_start, component_mask, axis_mask;
+  ptrdiff_t *stride, stridev;
 
   //assert(rank >= 0); // Note: Always true !
   if (rank == 0) {
@@ -146,13 +146,13 @@ int connect(
 
 static void recursive_copy(
      int axis,
-     register size_t mask)
+     size_t mask)
 {
-  register size_t len = g_axis_len[axis] - 2;
+  size_t len = g_axis_len[axis] - 2;
 
   if (axis == 0) {
-    register size_t *outimagep;
-    register char *inimagep, inbackground;
+    size_t *outimagep;
+    char *inimagep, inbackground;
 
     inimagep = g_inimagep;
     inbackground = g_inbackground;

--- a/Utilities/VTK/vtkImageConnectivity.h
+++ b/Utilities/VTK/vtkImageConnectivity.h
@@ -32,7 +32,7 @@ class VTK_CIP_UTILITIES_EXPORT vtkImageConnectivity : public vtkImageAlgorithm
 public:
   static vtkImageConnectivity *New();
   vtkTypeMacro(vtkImageConnectivity,vtkImageAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   /// Function
   void SetFunction(int func) {
@@ -93,7 +93,7 @@ protected:
 #if (VTK_MAJOR_VERSION <= 5)
   void ExecuteData(vtkDataObject *);
 #else
-  void ExecuteDataWithInformation(vtkDataObject *, vtkInformation *);
+  void ExecuteDataWithInformation(vtkDataObject *, vtkInformation *) override;
 #endif
 
 private:

--- a/Utilities/VTK/vtkImageErode.h
+++ b/Utilities/VTK/vtkImageErode.h
@@ -42,7 +42,7 @@ protected:
   float Foreground;
 
   void ThreadedExecute(vtkImageData *inData, vtkImageData *outData,
-    int extent[6], int id);
+    int extent[6], int id) override;
 };
 
 #endif

--- a/Utilities/VTK/vtkImageNeighborhoodFilter.h
+++ b/Utilities/VTK/vtkImageNeighborhoodFilter.h
@@ -29,7 +29,7 @@ class VTK_CIP_UTILITIES_EXPORT vtkImageNeighborhoodFilter : public vtkImageSpati
 public:
   static vtkImageNeighborhoodFilter *New();
   vtkTypeMacro(vtkImageNeighborhoodFilter,vtkImageSpatialAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
   
   /// 
   /// Mask that defines area of interest in the neighborhood.

--- a/Utilities/VTK/vtkNRRDReaderCIP.h
+++ b/Utilities/VTK/vtkNRRDReaderCIP.h
@@ -80,21 +80,21 @@ public:
   /// Get a value given a key in the header
   const char* GetHeaderValue(const char *key);
 
-  virtual void PrintSelf(ostream& os, vtkIndent indent);
+  virtual void PrintSelf(ostream& os, vtkIndent indent) override;
 
   ///  is the given file name a NRRD file?
-  virtual int CanReadFile(const char* filename);
+  virtual int CanReadFile(const char* filename) override;
 
   ///
   /// Valid extentsions
-  virtual const char* GetFileExtensions()
+  virtual const char* GetFileExtensions() override
     {
       return ".nhdr .nrrd";
     }
 
   ///
   /// A descriptive name for this format
-  virtual const char* GetDescriptiveName()
+  virtual const char* GetDescriptiveName() override
     {
       return "NRRD - Nearly Raw Raster Data";
     }
@@ -224,8 +224,8 @@ virtual void AllocateOutputData(vtkImageData *out, int *uExtent)
     { Superclass::AllocateOutputData(out, uExtent); }
 void AllocatePointData(vtkImageData *out);
 #else
-virtual vtkImageData * AllocateOutputData(vtkDataObject *out, vtkInformation* outInfo);
-virtual void AllocateOutputData(vtkImageData *out, vtkInformation* outInfo, int *uExtent)
+virtual vtkImageData * AllocateOutputData(vtkDataObject *out, vtkInformation* outInfo) override;
+virtual void AllocateOutputData(vtkImageData *out, vtkInformation* outInfo, int *uExtent) override
     { Superclass::AllocateOutputData(out, outInfo, uExtent); }
 void AllocatePointData(vtkImageData *out, vtkInformation* outInfo);
 #endif
@@ -252,11 +252,11 @@ protected:
 
   std::map <std::string, std::string> HeaderKeyValue;
 
-  virtual void ExecuteInformation();
+  virtual void ExecuteInformation() override;
 #if (VTK_MAJOR_VERSION <= 5)
   virtual void ExecuteData(vtkDataObject *out);
 #else
-  virtual void ExecuteDataWithInformation(vtkDataObject *output, vtkInformation* outInfo);
+  virtual void ExecuteDataWithInformation(vtkDataObject *output, vtkInformation* outInfo) override;
 #endif
 
   int tenSpaceDirectionReduce(Nrrd *nout, const Nrrd *nin, double SD[9]);

--- a/Utilities/VTK/vtkNRRDWriterCIP.h
+++ b/Utilities/VTK/vtkNRRDWriterCIP.h
@@ -22,7 +22,7 @@ class VTK_CIP_UTILITIES_EXPORT vtkNRRDWriterCIP : public vtkWriter
 public:
 
   vtkTypeMacro(vtkNRRDWriterCIP,vtkWriter);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   static vtkNRRDWriterCIP *New();
 
@@ -69,11 +69,11 @@ protected:
   vtkNRRDWriterCIP();
   ~vtkNRRDWriterCIP();
 
-  virtual int FillInputPortInformation(int port, vtkInformation *info);
+  virtual int FillInputPortInformation(int port, vtkInformation *info) override;
 
   ///
   /// Write method. It is called by vtkWriter::Write();
-  void WriteData();
+  void WriteData() override;
 
   ///
   /// Flag to set to on when a write error occured

--- a/Utilities/VTK/vtkSuperquadricTensorGlyphFilter.h
+++ b/Utilities/VTK/vtkSuperquadricTensorGlyphFilter.h
@@ -52,7 +52,7 @@ class VTK_CIP_UTILITIES_EXPORT vtkSuperquadricTensorGlyphFilter : public vtkPoly
 public:
   vtkTypeMacro(vtkSuperquadricTensorGlyphFilter,vtkPolyDataAlgorithm);
 
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   static vtkSuperquadricTensorGlyphFilter *New();
 
@@ -73,8 +73,8 @@ protected:
   ~vtkSuperquadricTensorGlyphFilter();
 
   /* implementation of algorithm */
-  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
-  int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *);
+  int RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
+  int RequestInformation(vtkInformation *, vtkInformationVector **, vtkInformationVector *) override;
 
   //virtual int FillInputPortInformation(int port, vtkInformation* info);
 


### PR DESCRIPTION
Adds override keyword
Moves from vcl_/vnl_math to std:: or itk::Math

Some other small cleanups to fix tons of warnings
and many errors.