### PR TITLE
COMP: fix warnings about types and overrides

### DIFF
--- a/Common/vtkMaskBoundingBox.h
+++ b/Common/vtkMaskBoundingBox.h
@@ -20,7 +20,7 @@ class VTK_CIP_COMMON_EXPORT vtkMaskBoundingBox : public vtkAlgorithm
   static vtkMaskBoundingBox *New();
 
   vtkTypeMacro(vtkMaskBoundingBox, vtkAlgorithm);
-  void PrintSelf(ostream& os, vtkIndent indent);
+  void PrintSelf(ostream& os, vtkIndent indent) override;
 
   // Description:
   // Set the Input of a filter.

--- a/Utilities/ITKStrain/itkStrainImageFilter.hxx
+++ b/Utilities/ITKStrain/itkStrainImageFilter.hxx
@@ -93,7 +93,7 @@ StrainImageFilter< TInputImage, TOperatorValueType, TOutputValueType >
     }
 
   OutputImageType * output = this->GetOutput();
-  output->FillBuffer( NumericTraits< OutputPixelType >::Zero );
+  output->FillBuffer( NumericTraits< TOutputValueType >::Zero );
 }
 
 template< typename TInputImage, typename TOperatorValueType, typename TOutputValueType >


### PR DESCRIPTION
Here are a few more compile warning fixes.

