### PR TITLE
COMP: fix namespace for new itk

### DIFF
--- a/CommandLineTools/SegmentLungAirways/SegmentLungAirways.cxx
+++ b/CommandLineTools/SegmentLungAirways/SegmentLungAirways.cxx
@@ -1832,7 +1832,7 @@ int main( int argc, char *argv[] )
 
     typedef itk::MergeLabelMapFilter< ShapeLabelMapType > MergeFilterType;
     MergeFilterType::Pointer mergeFilter = MergeFilterType::New();
-    mergeFilter->SetMethod(MergeFilterType::PACK);
+    mergeFilter->SetMethod(itk::PACK);
 
     ShapeLabelType::Pointer labelConverter = ShapeLabelType::New();
     labelConverter->SetInputForegroundValue(cip::AIRWAY);


### PR DESCRIPTION
Fixes this compile error with the suggested change.

 91%] Building CXX object CommandLineTools/SegmentLungAirways/CMakeFiles/SegmentLungAirwaysLib.dir/SegmentLungAirways.cxx.o
/Users/pieper/slicer/latest/SlicerCIP-build/CIP/CommandLineTools/SegmentLungAirways/SegmentLungAirways.cxx:1835:28: error:
      no member named 'PACK' in
      'itk::MergeLabelMapFilter<itk::LabelMap<itk::ShapeLabelObject<unsigned
      long, 3> > >'; did you mean 'itk::PACK'?
    mergeFilter->SetMethod(MergeFilterType::PACK);
                           ^~~~~~~~~~~~~~~~~~~~~
                           itk::PACK
/s/ITK/Modules/Filtering/LabelMap/include/itkMergeLabelMapFilter.h:61:35: note:
      'itk::PACK' declared here
static constexpr ChoiceMethodEnum PACK = ChoiceMethodEnum::PACK;
                                  ^
1 error generated.