### PR TITLE
COMP: Fix compatibility with ITK-5.2

### DIFF
--- a/CommandLineTools/SegmentLungAirways/SegmentLungAirways.cxx
+++ b/CommandLineTools/SegmentLungAirways/SegmentLungAirways.cxx
@@ -1832,7 +1832,12 @@ int main( int argc, char *argv[] )
 
     typedef itk::MergeLabelMapFilter< ShapeLabelMapType > MergeFilterType;
     MergeFilterType::Pointer mergeFilter = MergeFilterType::New();
+
+#if (ITK_VERSION_MAJOR < 5 || (ITK_VERSION_MAJOR == 5 && ITK_VERSION_MINOR < 2))
     mergeFilter->SetMethod(MergeFilterType::PACK);
+#else
+    mergeFilter->SetMethod(itk::ChoiceMethodEnum::PACK);
+#endif
 
     ShapeLabelType::Pointer labelConverter = ShapeLabelType::New();
     labelConverter->SetInputForegroundValue(cip::AIRWAY);


### PR DESCRIPTION
Fixes build error with ITK-5.2:

> D:\D\P\S-0-E-b\Chest_Imaging_Platform-build\CIP\CommandLineTools\SegmentLungAirways\SegmentLungAirways.cxx(1835,45): error C2039: 'PACK': is not a member of 'itk::MergeLabelMapFilter<ShapeLabelMapType>' [D:\D\P\S-0-E-b\Chest_Imaging_Platform-build\CIP-build\CommandLineTools\SegmentLungAirways\SegmentLungAirwaysLib.vcxproj] [D:\D\P\S-0-E-b\Chest_Imaging_Platform-build\CIP.vcxproj]

(https://slicer.cdash.org/viewBuildError.php?buildid=2370195)
