### PR TITLE
COMP: Fix build with projects that use C++ standard >11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,17 @@ project(${PRIMARY_PROJECT_NAME})
 
 
 #-----------------------------------------------------------------------------
-# Enable C++11
+# Set C++ standard version and extensions
 #-----------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+# Cache the variable values to allow setting a value externally.
+set(_minimum_cxx_standard "11")
+set(CMAKE_CXX_STANDARD "${_minimum_cxx_standard}" CACHE STRING "C++ standard")
+if("${CMAKE_CXX_STANDARD}" LESS "${_minimum_cxx_standard}")
+  message(FATAL_ERROR "CMAKE_CXX_STANDARD must be equal or larger than ${_minimum_cxx_standard}")
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "C++ standard required")
+set(CMAKE_CXX_EXTENSIONS OFF CACHE STRING "C++ extensions")
 message(STATUS "${_msg} - C++${CMAKE_CXX_STANDARD}")
-
 
 #-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default


### PR DESCRIPTION
Slicer switched to C++14, therefore the hardcoded C++ standard version in CIP caused a configuration conflict.

```
CMake Error at /Volumes/D/P/S-0-build/Slicer-build/SlicerConfig.cmake:976 (message):
  Variable CMAKE_CXX_STANDARD defined prior calling 'find_package(Slicer)'
  does NOT match value used to configure Slicer.  It probably means that a
  different CMAKE_CXX_STANDARD has been used to configure this project and
  Slicer.

  CMAKE_CXX_STANDARD=11

  Slicer_CMAKE_CXX_STANDARD=14
Call Stack (most recent call first):
  /Volumes/D/P/S-0-build/Slicer-build/SlicerConfig.cmake:990 (slicer_config_set_compiler_ep)
  CMakeLists.txt:37 (find_package)

-- Configuring incomplete, errors occurred!
See also "/Volumes/D/P/S-0-E-b/Chest_Imaging_Platform-build/CMakeFiles/CMakeOutput.log".
```


Fixed by making the version externally configurable.
