### PR TITLE
Fix Cxx17 incompatibility issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,13 +7,17 @@ project(${PRIMARY_PROJECT_NAME})
 
 
 #-----------------------------------------------------------------------------
-# Enable C++11
+# Set C++ standard version and extensions
 #-----------------------------------------------------------------------------
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+# Cache the variable values to allow setting a value externally.
+set(_minimum_cxx_standard "11")
+set(CMAKE_CXX_STANDARD "${_minimum_cxx_standard}" CACHE STRING "C++ standard")
+if("${CMAKE_CXX_STANDARD}" LESS "${_minimum_cxx_standard}")
+  message(FATAL_ERROR "CMAKE_CXX_STANDARD must be equal or larger than ${_minimum_cxx_standard}")
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON CACHE STRING "C++ standard required")
+set(CMAKE_CXX_EXTENSIONS OFF CACHE STRING "C++ extensions")
 message(STATUS "${_msg} - C++${CMAKE_CXX_STANDARD}")
-
 
 #-----------------------------------------------------------------------------
 # Superbuild Option - Enabled by default

--- a/Common/vtkMultipleReconstructionKernelsPhaseCongruency.cxx
+++ b/Common/vtkMultipleReconstructionKernelsPhaseCongruency.cxx
@@ -23,6 +23,8 @@
 #include "vtkExecutive.h"
 #include "vtkStreamingDemandDrivenPipeline.h"
 
+#include <cmath>
+
 #define VTK_EPS 1e-15
 
 vtkStandardNewMacro(vtkMultipleReconstructionKernelsPhaseCongruency);

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.h
@@ -193,7 +193,7 @@ public:
    * pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */  
-  virtual void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;
+  virtual void GenerateInputRequestedRegion() override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter.hxx
@@ -98,7 +98,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 template <class TInputImage, class TOutputImage>
 void 
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
-::GenerateInputRequestedRegion() throw(InvalidRequestedRegionError)
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.h
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.h
@@ -196,7 +196,7 @@ public:
    * pipeline execution model.
    *
    * \sa ImageToImageFilter::GenerateInputRequestedRegion()  */  
-  virtual void GenerateInputRequestedRegion() throw(InvalidRequestedRegionError);
+  virtual void GenerateInputRequestedRegion();
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.hxx
+++ b/Utilities/LesionSizingToolkit/itkCannyEdgeDetectionRecursiveGaussianImageFilter2.hxx
@@ -101,7 +101,7 @@ CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage, TOutputImage>
 template <class TInputImage, class TOutputImage>
 void 
 CannyEdgeDetectionRecursiveGaussianImageFilter<TInputImage,TOutputImage>
-::GenerateInputRequestedRegion() throw(InvalidRequestedRegionError)
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();

--- a/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.h
+++ b/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.h
@@ -84,8 +84,7 @@ public:
   typedef CannyEdgesFeatureGenerator< ImageDimension > CannyEdgesFeatureGeneratorType;
   typedef typename CannyEdgesFeatureGeneratorType::SigmaArrayType SigmaArrayType;
 
-  virtual void GenerateInputRequestedRegion()
-            throw(InvalidRequestedRegionError) override;
+  virtual void GenerateInputRequestedRegion() override;
 
 #ifdef ITK_USE_CONCEPT_CHECKING
   /** Begin concept checking */

--- a/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.hxx
+++ b/Utilities/LesionSizingToolkit/itkLesionSegmentationImageFilter8.hxx
@@ -102,7 +102,7 @@ LesionSegmentationImageFilter8()
 template <class TInputImage, class TOutputImage>
 void
 LesionSegmentationImageFilter8<TInputImage,TOutputImage>
-::GenerateInputRequestedRegion() throw(InvalidRequestedRegionError)
+::GenerateInputRequestedRegion()
 {
   // call the superclass' implementation of this method
   Superclass::GenerateInputRequestedRegion();


### PR DESCRIPTION
ITK, VTK, etc. libraries require more recent C++ standard version (Cxx17) and CIP had build errors in this environment. These commits fix the build errors.